### PR TITLE
Add copy-to-clipboard button for invitation URL

### DIFF
--- a/app/javascript/ui.js
+++ b/app/javascript/ui.js
@@ -39,6 +39,24 @@ function initTabs() {
   })
 }
 
+function initCopyButtons() {
+  document.querySelectorAll("[data-copy-target]").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const source = document.getElementById(btn.dataset.copyTarget)
+      if (!source) return
+      navigator.clipboard.writeText(source.innerText.trim()).then(() => {
+        const original = btn.textContent
+        btn.textContent = "Skopiowano!"
+        btn.disabled = true
+        setTimeout(() => {
+          btn.textContent = original
+          btn.disabled = false
+        }, 2000)
+      })
+    })
+  })
+}
+
 function initAlerts() {
   document.querySelectorAll("[data-alert]").forEach((alert) => {
     const close = alert.querySelector("[data-alert-close]")
@@ -53,6 +71,7 @@ function init() {
   initMobileNav()
   initTabs()
   initAlerts()
+  initCopyButtons()
 }
 
 document.addEventListener("DOMContentLoaded", init)

--- a/app/views/users/create.html.erb
+++ b/app/views/users/create.html.erb
@@ -4,5 +4,13 @@
 
 <section class='card card-body'>
   <p class='mb-2 text-muted'>Utworzono konto. Link aktywacyjny:</p>
-  <pre class='overflow-x-auto rounded-lg bg-surface p-3 text-sm text-ink'><%= invitation_url(token: @token) %></pre>
+  <div class='overflow-hidden rounded-lg border border-line bg-surface'>
+    <div class='flex items-center justify-between gap-3 border-b border-line px-3 py-2'>
+      <span class='text-xs font-semibold uppercase tracking-wide text-muted'>Link aktywacyjny</span>
+      <button class='btn btn-sm btn-outline' data-copy-target='invitation-url' type='button'>
+        <i class='fa fa-copy'></i> Kopiuj
+      </button>
+    </div>
+    <pre id='invitation-url' class='p-3 text-sm text-ink' style='white-space: pre-wrap; word-break: break-all; overflow-wrap: break-word;'><%= invitation_url(token: @token) %></pre>
+  </div>
 </section>


### PR DESCRIPTION
## Summary

- Replaces the plain `<pre>` block on the invitation result page with a mini-card widget (header row + URL body)
- Header row shows a "Kopiuj" button alongside a "LINK AKTYWACYJNY" label — button never overlaps the URL text
- URL is displayed in a wrapping `<pre>` (`white-space: pre-wrap` + `word-break: break-all`) so long tokens fill the full width and continue on the next line
- Clicking "Kopiuj" copies the URL via `navigator.clipboard` and briefly shows "Skopiowano!" as confirmation
- Works for both new invitation creation and the resend flow (same template)

## Test plan

- [ ] Create a new invitation as admin → confirm URL wraps correctly and "Kopiuj" button appears in the header row
- [ ] Click "Kopiuj" → button shows "Skopiowano!" for ~2 s then reverts; pasted value matches the displayed URL
- [ ] Use "Resend invitation" from the users index → same widget appears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)