### PR TITLE
Disable mobile autocapitalize on text inputs

### DIFF
--- a/app/views/matches/_form.html.erb
+++ b/app/views/matches/_form.html.erb
@@ -3,11 +3,11 @@
     <div class='grid grid-cols-1 gap-4 sm:grid-cols-2'>
       <div>
         <%= f.label :team_a, 'Drużyna 1', class: 'label' %>
-        <%= f.text_field :team_a, class: 'field' %>
+        <%= f.text_field :team_a, class: 'field', autocapitalize: 'none' %>
       </div>
       <div>
         <%= f.label :team_b, 'Drużyna 2', class: 'label' %>
-        <%= f.text_field :team_b, class: 'field' %>
+        <%= f.text_field :team_b, class: 'field', autocapitalize: 'none' %>
       </div>
     </div>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -5,7 +5,7 @@
       <div class='space-y-4'>
         <div>
           <%= f.label :username, 'Login', class: 'label' %>
-          <%= f.text_field :username, placeholder: 'Login', class: 'field', autocomplete: 'off', tabindex: 1, autofocus: true %>
+          <%= f.text_field :username, placeholder: 'Login', class: 'field', autocomplete: 'off', autocapitalize: 'none', tabindex: 1, autofocus: true %>
         </div>
         <div>
           <%= f.label :password, 'Hasło', class: 'label' %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -7,7 +7,7 @@
     <div class='flex flex-col gap-3 sm:flex-row sm:items-end'>
       <div class='flex-1'>
         <%= f.label :username, 'Login', class: 'label' %>
-        <%= f.text_field :username, class: 'field' %>
+        <%= f.text_field :username, class: 'field', autocapitalize: 'none' %>
       </div>
       <%= f.submit 'Generuj zaproszenie', class: 'btn btn-brand' %>
     </div>


### PR DESCRIPTION
## Summary

- Added `autocapitalize="none"` to all `text_field` inputs across the app
- Fixes the issue where mobile keyboards (iOS/Android) were automatically capitalizing the first character typed in login, username, and team name fields

## Affected fields

- Login form — username field (`sessions/new.html.erb`)
- Invitations page — username field (`users/index.html.erb`)
- Match form — team A and team B fields (`matches/_form.html.erb`)

## Test plan

- [ ] Open login page on a phone (or Chrome DevTools mobile emulator), tap the username field, verify first character is not autocapitalized
- [ ] Same check on the match form team name fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)