### PR TITLE
Refine match views: legend, result colors, live badge, URL tabs

### DIFF
--- a/frontend/src/components/BetGrid.tsx
+++ b/frontend/src/components/BetGrid.tsx
@@ -1,4 +1,4 @@
-import { BET_TYPES, betPillClass } from '@/lib/bets'
+import { BET_TYPES, betPillClass, winningBets } from '@/lib/bets'
 import { formattedOdds } from '@/lib/format'
 import type { BetType, Match } from '@/api/types'
 
@@ -11,22 +11,28 @@ interface Props {
 }
 
 // The 1 / X / 2 / 1X / X2 / 12 row. Mirrors matches/_buttons.html.erb: a started
-// match locks the pills; the chosen pill is highlighted.
+// match locks the pills, the chosen pill is highlighted, and a finished match
+// marks the viewer's own pick as a hit or a miss.
 export default function BetGrid({ match, myAnswer, onBet, pending }: Props) {
+  const interactive = Boolean(onBet) && !match.started
+  const scored = match.finished ? new Set(winningBets(match.result_a, match.result_b)) : null
+
   return (
     <div className="bet-grid">
       {BET_TYPES.map(([result, label]) => {
         const active = myAnswer === result
+        const isScored = scored?.has(result) ?? false
         const odds = formattedOdds(match.odds[result])
-        const locked = match.started
         return (
           <button
             key={result}
             type="button"
-            disabled={locked || pending || !onBet}
+            disabled={!interactive || pending}
             onClick={() => onBet?.(result)}
-            aria-label={`Typ ${label}, kurs ${odds}${active ? ', wybrany' : ''}`}
-            className={betPillClass(active, locked)}
+            aria-label={`Typ ${label}, kurs ${odds}${
+              active ? `, wybrany${match.finished ? (isScored ? ', trafiony' : ', nietrafiony') : ''}` : ''
+            }`}
+            className={betPillClass({ active, scored: isScored, finished: match.finished, interactive })}
           >
             <span className="bet-key">{label}</span>
             <span className="bet-odds">{odds}</span>

--- a/frontend/src/components/MatchLine.tsx
+++ b/frontend/src/components/MatchLine.tsx
@@ -6,9 +6,18 @@ import type { Match } from '@/api/types'
 // Clickable match line: time on the left, then "TeamA <flag>  score  <flag> TeamB"
 // with the score centered. Mirrors matches/_match_line.html.erb.
 export default function MatchLine({ match }: { match: Match }) {
+  const live = match.started && !match.finished
   return (
     <Link to={`/matches/${match.id}`} className="group flex items-center gap-2 sm:flex-1 sm:gap-3">
-      <span className="w-11 shrink-0 text-sm font-semibold tabular-nums text-muted">{formatTime(match.start)}</span>
+      <span className="flex w-11 shrink-0 flex-col gap-0.5">
+        <span className="text-sm font-semibold tabular-nums text-muted">{formatTime(match.start)}</span>
+        {live && (
+          <span className="inline-flex items-center gap-1 text-[10px] font-bold leading-none text-amber-600">
+            <span className="h-1.5 w-1.5 rounded-full bg-amber-500 motion-safe:animate-pulse" aria-hidden="true" />
+            Trwa
+          </span>
+        )}
+      </span>
       <span className="flex flex-1 items-center justify-center gap-2 sm:gap-3">
         <span className="flex-1 text-right font-semibold text-ink group-hover:text-brand">
           {match.team_a}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -58,7 +58,7 @@
 
   /* Admin user list: a compact 2x2 card on mobile (user + status on top,
      payment + actions below) that flows into aligned columns with a header on >=sm. */
-  .user-head { @apply hidden gap-x-4 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted; }
+  .user-head { @apply hidden gap-x-4 px-4 py-2 text-xs font-semibold text-muted; }
   .user-row {
     @apply grid items-center gap-x-4 gap-y-1.5 px-4 py-3;
     grid-template-columns: minmax(0, 1fr) auto;
@@ -89,8 +89,13 @@
   .bet-key { @apply text-[11px] font-bold uppercase tracking-wide; }
   .bet-odds { @apply text-xs font-semibold tabular-nums; }
   .bet-idle { @apply border-brand/30 bg-white text-ink hover:border-brand hover:bg-brand-tint hover:text-ink; }
-  .bet-active { @apply border-brand bg-brand text-white shadow-sm hover:text-white; }
   .bet-locked { @apply pointer-events-none border-line bg-surface text-muted; }
+  /* The viewer's pick before the result is known — neutral gray ("picked, undecided"). */
+  .bet-pick { @apply border-[#969b9d] bg-[#969b9d] text-white shadow-sm; }
+  /* Finished match: the viewer's pick that scored (strong green). */
+  .bet-hit { @apply border-brand bg-brand text-white shadow-sm; }
+  /* Finished match: the viewer's pick that missed (light red). */
+  .bet-miss { @apply border-danger/40 bg-danger-tint text-danger; }
 }
 
 /* "Drzewko mode" (opt-in via Ustawienia → Dostępność): the current user's row in

--- a/frontend/src/lib/bets.ts
+++ b/frontend/src/lib/bets.ts
@@ -10,9 +10,47 @@ export const BET_TYPES: ReadonlyArray<readonly [BetType, string]> = [
   ['not_tie', '12'],
 ]
 
-// CSS classes for an interactive bet pill. Mirrors MatchesHelper#bet_pill_class.
-export function betPillClass(active: boolean, started: boolean): string {
-  if (active) return `bet bet-active${started ? ' pointer-events-none' : ''}`
-  if (started) return 'bet bet-locked'
-  return 'bet bet-idle'
+// Human-readable meaning of each symbol, shown as the aligned legend above the
+// pills (mirrors the column headers in Ania's typerek).
+export const BET_LEGEND: Record<BetType, string> = {
+  win_a: 'Drużyna 1',
+  tie: 'Remis',
+  win_b: 'Drużyna 2',
+  win_tie_a: '1 lub X',
+  win_tie_b: 'X lub 2',
+  not_tie: '1 lub 2',
+}
+
+// The bet types that score points for a finished match. Mirrors Match#winning_list.
+export function winningBets(resultA: number | null, resultB: number | null): BetType[] {
+  if (resultA == null || resultB == null) return []
+  if (resultA > resultB) return ['win_a', 'win_tie_a', 'not_tie']
+  if (resultA < resultB) return ['win_b', 'win_tie_b', 'not_tie']
+  return ['tie', 'win_tie_a', 'win_tie_b']
+}
+
+interface PillState {
+  // The viewer picked this bet type.
+  active: boolean
+  // Finished match and this bet type scored points.
+  scored: boolean
+  // The match has a final result.
+  finished: boolean
+  // The pill can be clicked (an open match the viewer may bet on).
+  interactive: boolean
+}
+
+// CSS classes for one bet pill.
+// - Finished match: the viewer's own pick is strong green when it scored, red
+//   when it missed; every other pill stays neutral.
+// - Otherwise: the viewer's pick is a neutral gray ("picked, result unknown"),
+//   open pills are idle, and a started-but-unfinished match locks the rest.
+export function betPillClass({ active, scored, finished, interactive }: PillState): string {
+  if (finished) {
+    if (active) return scored ? 'bet bet-hit' : 'bet bet-miss'
+    return 'bet bet-locked'
+  }
+  if (active) return `bet bet-pick${interactive ? '' : ' pointer-events-none'}`
+  if (interactive) return 'bet bet-idle'
+  return 'bet bet-locked'
 }

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -20,7 +20,11 @@ export function formatTime(iso: string): string {
 }
 
 export function formatDateLong(iso: string): string {
-  return new Date(iso).toLocaleDateString(LOCALE, { weekday: 'long', day: 'numeric', month: 'long' })
+  // pl-PL yields a lowercase weekday ("czwartek, 4 czerwca"); capitalize just the
+  // first letter so it reads as a proper label ("Czwartek, 4 czerwca"). A CSS
+  // `capitalize` would wrongly upper-case the month too.
+  const text = new Date(iso).toLocaleDateString(LOCALE, { weekday: 'long', day: 'numeric', month: 'long' })
+  return text.charAt(0).toUpperCase() + text.slice(1)
 }
 
 // ISO timestamp -> value for an <input type="datetime-local"> (local wall time).

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -40,7 +40,7 @@ export default function HomePage() {
         wszystkich uczestników dla danego meczu. Nie możemy wtedy modyfikować swojego wyboru.
       </p>
       <div className="rounded-lg bg-amber-50 p-3 text-sm text-amber-800">
-        <strong>UWAGA!</strong> W meczach fazy pucharowej typujemy wyniki tylko do 90. minuty spotkania. Typ
+        <strong>Uwaga!</strong> W meczach fazy pucharowej typujemy wyniki tylko do 90. minuty spotkania. Typ
         „remis” jest jak najbardziej poprawny. Oznacza to, że drużyny po rozegraniu regulaminowych 90 minut
         będą miały dogrywkę.
       </div>

--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '@/auth/AuthContext'
 import { ErrorBox, Loading } from '@/components/Status'
 import Flag from '@/components/Flag'
 import BetGrid from '@/components/BetGrid'
-import { BET_TYPES } from '@/lib/bets'
+import { BET_TYPES, betPillClass, winningBets } from '@/lib/bets'
 import { formatShort, formattedOdds, formattedScore } from '@/lib/format'
 import { useDocumentTitle } from '@/lib/useDocumentTitle'
 
@@ -19,6 +19,9 @@ export default function MatchPage() {
 
   if (isLoading) return <Loading />
   if (isError || !match) return <ErrorBox />
+
+  const scored = match.finished ? new Set(winningBets(match.result_a, match.result_b)) : null
+  const live = match.started && !match.finished
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
@@ -47,6 +50,14 @@ export default function MatchPage() {
             {match.team_b}
           </div>
         </div>
+        {live && (
+          <p className="mt-3 text-center">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-bold text-amber-700">
+              <span className="h-2 w-2 rounded-full bg-amber-500 motion-safe:animate-pulse" aria-hidden="true" />
+              Trwa
+            </span>
+          </p>
+        )}
         <p className="mt-3 text-center text-sm text-muted">
           <i className="fa fa-clock-o" aria-hidden="true" /> {formatShort(match.start)}
         </p>
@@ -88,15 +99,21 @@ export default function MatchPage() {
                   </Link>
                 </div>
                 {participant.result == null ? (
-                  <span className="text-sm text-muted sm:ml-auto">brak typu</span>
+                  <span className="text-sm text-muted sm:ml-auto">Brak typu</span>
                 ) : (
                   <div className="bet-grid sm:ml-auto sm:w-[340px]">
                     {BET_TYPES.map(([result, label]) => {
                       const chosen = participant.result === result
+                      const isScored = scored?.has(result) ?? false
                       return (
                         <div
                           key={result}
-                          className={`bet ${chosen ? 'bet-active' : 'border-line bg-surface/60 text-muted'}`}
+                          className={betPillClass({
+                            active: chosen,
+                            scored: isScored,
+                            finished: match.finished,
+                            interactive: false,
+                          })}
                         >
                           <span className="bet-key">{label}</span>
                           <span className="bet-odds">{formattedOdds(match.odds[result])}</span>

--- a/frontend/src/pages/MatchesPage.tsx
+++ b/frontend/src/pages/MatchesPage.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { useMatches, usePlaceBet } from '@/api/hooks'
 import { formatDateLong, groupByDay } from '@/lib/format'
+import { BET_TYPES, BET_LEGEND } from '@/lib/bets'
 import MatchLine from '@/components/MatchLine'
 import BetGrid from '@/components/BetGrid'
 import { ErrorBox, Loading } from '@/components/Status'
@@ -19,13 +20,24 @@ function MatchSection({ matches }: { matches: Match[] }) {
       {groupByDay(matches).map((group) => (
         <section key={group.start} className="card overflow-hidden">
           <div className="card-header">
-            <h3 className="text-sm font-bold uppercase tracking-wide text-muted">{formatDateLong(group.start)}</h3>
+            <h3 className="text-sm font-bold text-muted">{formatDateLong(group.start)}</h3>
+            {/* Legend explaining the 1 / X / 2 / 1X / X2 / 12 symbols, aligned over
+                the bet pills below (hidden on mobile, where the row stacks). */}
+            <div className="hidden w-[340px] grid-cols-6 gap-1.5 sm:grid sm:gap-2">
+              {BET_TYPES.map(([result]) => (
+                <div key={result} className="text-center text-[10px] leading-tight text-muted">
+                  {BET_LEGEND[result]}
+                </div>
+              ))}
+            </div>
           </div>
           <div className="divide-y divide-line/60">
             {group.items.map((match) => (
               <div
                 key={match.id}
-                className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-5"
+                className={`flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-5${
+                  match.started && !match.finished ? ' bg-amber-50/70' : ''
+                }`}
               >
                 <MatchLine match={match} />
                 <div className="sm:w-[340px]">
@@ -48,7 +60,12 @@ function MatchSection({ matches }: { matches: Match[] }) {
 // Mirrors matches/index.html.erb (tabs Aktualne / Zakończone).
 export default function MatchesPage() {
   const { data, isLoading, isError } = useMatches()
-  const [tab, setTab] = useState<'future' | 'finished'>('future')
+  // The active tab lives in the URL (?status=finished) so a refresh or a shared
+  // link keeps you on the same tab.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const tab: 'future' | 'finished' = searchParams.get('status') === 'finished' ? 'finished' : 'future'
+  const selectTab = (next: 'future' | 'finished') =>
+    setSearchParams(next === 'finished' ? { status: 'finished' } : {}, { replace: true })
 
   useDocumentTitle('Mecze')
 
@@ -62,12 +79,12 @@ export default function MatchesPage() {
       </h1>
 
       <div className="mb-5 flex border-b border-line">
-        <button type="button" onClick={() => setTab('future')} className={`tab${tab === 'future' ? ' tab-active' : ''}`}>
+        <button type="button" onClick={() => selectTab('future')} className={`tab${tab === 'future' ? ' tab-active' : ''}`}>
           Aktualne <span className="badge-count">{data.not_finished.length}</span>
         </button>
         <button
           type="button"
-          onClick={() => setTab('finished')}
+          onClick={() => selectTab('finished')}
           className={`tab${tab === 'finished' ? ' tab-active' : ''}`}
         >
           Zakończone <span className="badge-count">{data.finished.length}</span>

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -34,13 +34,15 @@ export default function UserProfilePage() {
           {groupByDay(data.started_matches).map((group) => (
             <section key={group.start} className="card overflow-hidden">
               <div className="card-header">
-                <h3 className="text-sm font-bold uppercase tracking-wide text-muted">{formatDateLong(group.start)}</h3>
+                <h3 className="text-sm font-bold text-muted">{formatDateLong(group.start)}</h3>
               </div>
               <div className="divide-y divide-line/60">
                 {group.items.map((match) => (
                   <div
                     key={match.id}
-                    className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-5"
+                    className={`flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-5${
+                      match.started && !match.finished ? ' bg-amber-50/70' : ''
+                    }`}
                   >
                     <MatchLine match={match} />
                     <div className="sm:w-[340px]">

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -16,9 +16,9 @@ import { useDocumentTitle } from '@/lib/useDocumentTitle'
 
 function StatusBadge({ user }: { user: User }) {
   return user.active ? (
-    <span className="badge badge-success">aktywny</span>
+    <span className="badge badge-success">Aktywny</span>
   ) : (
-    <span className="badge badge-warning">zaproszony</span>
+    <span className="badge badge-warning">Zaproszony</span>
   )
 }
 
@@ -27,13 +27,9 @@ function FinToggle({ user }: { user: User }) {
   return (
     <button type="button" title="Kliknij, aby przełączyć" disabled={toggle.isPending} onClick={() => toggle.mutate(user.id)}>
       {user.fin ? (
-        <span className="badge badge-success cursor-pointer">
-          <i className="fa fa-check" aria-hidden="true" /> potwierdzony
-        </span>
+        <span className="badge badge-success cursor-pointer">Potwierdzony</span>
       ) : (
-        <span className="badge badge-danger cursor-pointer">
-          <i className="fa fa-times" aria-hidden="true" /> niepotwierdzony
-        </span>
+        <span className="badge badge-danger cursor-pointer">Niepotwierdzony</span>
       )}
     </button>
   )
@@ -129,7 +125,7 @@ export default function UsersPage() {
           <p className="mb-2 text-muted">Utworzono konto. Link aktywacyjny:</p>
           <div className="overflow-hidden rounded-lg border border-line bg-surface">
             <div className="flex items-center justify-between gap-3 border-b border-line px-3 py-2">
-              <span className="text-xs font-semibold uppercase tracking-wide text-muted">Link aktywacyjny</span>
+              <span className="text-xs font-semibold text-muted">Link aktywacyjny</span>
               <button type="button" className="btn btn-sm btn-outline" onClick={copyLink}>
                 <i className="fa fa-copy" aria-hidden="true" /> {copied ? 'Skopiowano!' : 'Kopiuj'}
               </button>


### PR DESCRIPTION
- Add an aligned 1/X/2 legend in the day header
- Color finished bets by the viewer's pick (green hit / red miss), gray while undecided
- Flag in-progress matches with a "Trwa" badge and amber row
- Keep the Aktualne/Zakończone tab in the URL (?status=finished) so refresh sticks
- Capitalize the date label and drop all-caps from labels and badges