### PR TITLE
Cache ranking history with a versioned key

### DIFF
--- a/app/controllers/api/v1/rankings_controller.rb
+++ b/app/controllers/api/v1/rankings_controller.rb
@@ -8,7 +8,14 @@ module Api
       end
 
       def history
-        render json: RankingHistorySerializer.call(Typerek::Ranking::History.new.call)
+        history = Typerek::Ranking::History
+        json = Rails.cache.fetch(
+          [history::CACHE_KEY, history.cache_version],
+          expires_in: 1.day
+        ) do
+          RankingHistorySerializer.call(history.new.call).to_json
+        end
+        render json: json
       end
     end
   end

--- a/lib/typerek/ranking/history.rb
+++ b/lib/typerek/ranking/history.rb
@@ -17,6 +17,23 @@ module Typerek
       Result = Struct.new(:matches, :series, keyword_init: true)
       SeriesEntry = Struct.new(:user, :positions, :points, keyword_init: true)
 
+      CACHE_KEY = 'api/v1/ranking_history'
+
+      # Fingerprint of every input that can change the chart. Bets are locked
+      # once a match starts (see Typerek::MakeBet::Handler), so answers of
+      # finished matches are immutable — the chart only moves when a match is
+      # edited (results/date) or the set of users changes. Both bump the
+      # respective table's max(updated_at)/count, so this string changes exactly
+      # when a recompute is needed and the cache self-invalidates.
+      def self.cache_version
+        [
+          Match.maximum(:updated_at)&.to_f,
+          Match.count,
+          User.maximum(:updated_at)&.to_f,
+          User.count
+        ].join('-')
+      end
+
       def call
         matches = Match.finished.reorder(start: :asc).to_a
         users   = User.includes(answers: :match).active.to_a


### PR DESCRIPTION
The bump chart was recomputed on every request (O(matches × users) plus loading all answers), even though it only changes when a match is edited or the set of users changes — bets are locked once a match starts.

Wrap the endpoint in Rails.cache.fetch keyed on max(updated_at)/count of Match and User, so the cache self-invalidates on the next request after any relevant change without manual sweeping.