### PR TITLE
Add opt-in bet lock, with user settings on the backend

### DIFF
--- a/app/controllers/api/v1/matches_controller.rb
+++ b/app/controllers/api/v1/matches_controller.rb
@@ -6,7 +6,7 @@ module Api
       def index
         not_finished = Match.not_finished.includes(:answers).accessible_by(current_ability)
         finished = Match.finished.includes(:answers).accessible_by(current_ability)
-        answers = current_user.answers.index_by(&:match_id).transform_values(&:result)
+        answers = current_user.answers.index_by(&:match_id)
 
         render json: {
           not_finished: MatchSerializer.many(not_finished, answers_by_match: answers),
@@ -17,7 +17,7 @@ module Api
       def show
         match = Match.includes(:answers).find(params[:id])
         authorize! :read, match
-        render json: MatchDetailSerializer.call(match, my_answer: my_answer(match))
+        render json: detail(match)
       end
 
       def update
@@ -25,7 +25,7 @@ module Api
         authorize! :update, match
 
         if match.update(match_params)
-          render json: MatchDetailSerializer.call(match, my_answer: my_answer(match))
+          render json: detail(match)
         else
           unprocessable!(match)
         end
@@ -44,10 +44,28 @@ module Api
         unprocessable!(e.message)
       end
 
+      def lock
+        answer = Typerek::SetLock::Handler.new(
+          user_id: current_user.id,
+          match_id: params[:id],
+          locked: params[:locked]
+        ).call
+        render json: AnswerSerializer.call(answer)
+      rescue Typerek::MatchNotFoundError
+        not_found!
+      rescue Typerek::Error => e
+        unprocessable!(e.message)
+      end
+
       private
 
+      def detail(match)
+        answer = my_answer(match)
+        MatchDetailSerializer.call(match, my_answer: answer&.result, my_locked: answer&.locked || false)
+      end
+
       def my_answer(match)
-        current_user.answers.find_by(match_id: match.id)&.result
+        current_user.answers.find_by(match_id: match.id)
       end
 
       def match_params

--- a/app/controllers/api/v1/profile_controller.rb
+++ b/app/controllers/api/v1/profile_controller.rb
@@ -6,6 +6,25 @@ module Api
       def show
         render json: CurrentUserSerializer.call(current_user)
       end
+
+      def update_settings
+        # Persist only the settings bag, skipping validations: the User model
+        # requires a password on every update (it is set during invitation
+        # acceptance, never present here), which would otherwise reject this.
+        current_user.settings = current_user.settings.merge(settings_params)
+        current_user.save!(validate: false)
+        render json: CurrentUserSerializer.call(current_user)
+      end
+
+      private
+
+      # Only known keys are accepted; values are coerced to booleans and merged
+      # into the existing settings bag, so a partial update leaves the rest intact.
+      def settings_params
+        params.require(:settings).permit(:drzewko_mode, :bet_lock).to_h.transform_values do |value|
+          ActiveModel::Type::Boolean.new.cast(value)
+        end
+      end
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  # Per-user UI preferences, stored in the `settings` jsonb column. New keys can be
+  # added here without a migration; everything defaults to off.
+  SETTINGS_DEFAULTS = { 'drzewko_mode' => false, 'bet_lock' => false }.freeze
+
   has_secure_password validations: false
 
   generates_token_for :invitation, expires_in: 72.hours do
@@ -32,5 +36,17 @@ class User < ApplicationRecord
 
   def accept_invitation(params = {})
     update(params.merge(invitation_accepted_at: DateTime.now))
+  end
+
+  def settings_with_defaults
+    SETTINGS_DEFAULTS.merge(settings || {})
+  end
+
+  def drzewko_mode?
+    settings_with_defaults['drzewko_mode'] == true
+  end
+
+  def bet_lock?
+    settings_with_defaults['bet_lock'] == true
   end
 end

--- a/app/serializers/api/v1/answer_serializer.rb
+++ b/app/serializers/api/v1/answer_serializer.rb
@@ -7,7 +7,8 @@ module Api
       def self.call(answer)
         {
           match_id: answer.match_id,
-          result: answer.result
+          result: answer.result,
+          locked: answer.locked
         }
       end
     end

--- a/app/serializers/api/v1/current_user_serializer.rb
+++ b/app/serializers/api/v1/current_user_serializer.rb
@@ -13,7 +13,11 @@ module Api
           username: user.username,
           admin: user.admin?,
           standing: entry && { rank: entry.position, points: entry.points },
-          discord_url: ENV['TYPEREK_DISCORD_URL'].presence
+          discord_url: ENV['TYPEREK_DISCORD_URL'].presence,
+          settings: {
+            drzewko_mode: user.drzewko_mode?,
+            bet_lock: user.bet_lock?
+          }
         }
       end
     end

--- a/app/serializers/api/v1/match_detail_serializer.rb
+++ b/app/serializers/api/v1/match_detail_serializer.rb
@@ -5,8 +5,8 @@ module Api
     # The `MatchDetail` schema: Match + `participants` (their bets), visible only
     # once the match has started.
     class MatchDetailSerializer
-      def self.call(match, my_answer: nil)
-        data = MatchSerializer.call(match, my_answer: my_answer)
+      def self.call(match, my_answer: nil, my_locked: false)
+        data = MatchSerializer.call(match, my_answer: my_answer, my_locked: my_locked)
         data[:participants] = participants(match) if match.started?
         data
       end

--- a/app/serializers/api/v1/match_serializer.rb
+++ b/app/serializers/api/v1/match_serializer.rb
@@ -2,14 +2,18 @@
 
 module Api
   module V1
-    # A serialized match. `my_answer` is the given viewer's bet (or nil). Flags are
-    # resolved client-side from the team name (frontend/src/lib/flags.ts).
+    # A serialized match. `my_answer` is the given viewer's bet (or nil) and
+    # `my_locked` whether they locked it. Flags are resolved client-side from the
+    # team name (frontend/src/lib/flags.ts).
     class MatchSerializer
       def self.many(matches, answers_by_match: {})
-        matches.map { |match| call(match, my_answer: answers_by_match[match.id]) }
+        matches.map do |match|
+          answer = answers_by_match[match.id]
+          call(match, my_answer: answer&.result, my_locked: answer&.locked || false)
+        end
       end
 
-      def self.call(match, my_answer: nil)
+      def self.call(match, my_answer: nil, my_locked: false)
         {
           id: match.id,
           team_a: match.team_a,
@@ -27,7 +31,8 @@ module Api
             win_tie_b: match.win_tie_b,
             not_tie: match.not_tie
           },
-          my_answer: my_answer
+          my_answer: my_answer,
+          my_locked: my_locked
         }
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,9 +9,13 @@ Rails.application.routes.draw do
       post 'auth/login', to: 'auth#login'
       post 'auth/logout', to: 'auth#logout'
       get 'me', to: 'profile#show'
+      patch 'me/settings', to: 'profile#update_settings'
 
       resources :matches, only: %i[index show update] do
-        member { put :bet }
+        member do
+          put :bet
+          put :lock
+        end
       end
 
       get 'ranking', to: 'rankings#show'

--- a/db/migrate/20260609120000_add_locked_to_answers.rb
+++ b/db/migrate/20260609120000_add_locked_to_answers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLockedToAnswers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :answers, :locked, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260609130000_add_settings_to_users.rb
+++ b/db/migrate/20260609130000_add_settings_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSettingsToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :settings, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_04_222527) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_09_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_04_222527) do
     t.integer "result"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.boolean "locked", default: false, null: false
     t.index ["match_id", "user_id"], name: "index_answers_on_match_id_and_user_id", unique: true
     t.index ["match_id"], name: "index_answers_on_match_id"
     t.index ["user_id"], name: "index_answers_on_user_id"
@@ -68,6 +69,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_04_222527) do
     t.string "invited_by_type", limit: 255
     t.boolean "fin", default: false
     t.string "password_digest"
+    t.jsonb "settings", default: {}, null: false
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
     t.index ["username"], name: "index_users_on_username", unique: true
   end

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -100,6 +100,19 @@ export function usePlaceBet() {
   })
 }
 
+// Locks or unlocks the viewer's bet on a match so it can't be changed by accident.
+export function useToggleLock() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ matchId, locked }: { matchId: number; locked: boolean }) =>
+      api.put<Answer>(`/matches/${matchId}/lock`, { locked }),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: queryKeys.matches })
+      qc.invalidateQueries({ queryKey: queryKeys.match(variables.matchId) })
+    },
+  })
+}
+
 export function useUpdateMatch(id: number) {
   const qc = useQueryClient()
   return useMutation({

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -18,6 +18,12 @@ export interface Standing {
   points: number
 }
 
+// Per-user UI preferences, persisted server-side (see UserSettings on the backend).
+export interface UserSettings {
+  drzewko_mode: boolean
+  bet_lock: boolean
+}
+
 export interface CurrentUser {
   id: number
   username: string
@@ -25,6 +31,7 @@ export interface CurrentUser {
   standing: Standing | null
   // Community Discord invite, served only to signed-in users; null when unset.
   discord_url: string | null
+  settings: UserSettings
 }
 
 export interface User {
@@ -47,6 +54,8 @@ export interface Match {
   result_b: number | null
   odds: Odds
   my_answer: BetType | null
+  // Whether the viewer locked their bet against accidental changes.
+  my_locked: boolean
 }
 
 export interface Participant {
@@ -66,6 +75,7 @@ export interface MatchList {
 export interface Answer {
   match_id: number
   result: BetType
+  locked: boolean
 }
 
 export interface RankingEntry {

--- a/frontend/src/components/BetGrid.tsx
+++ b/frontend/src/components/BetGrid.tsx
@@ -1,5 +1,6 @@
 import { BET_TYPES, betPillClass, winningBets } from '@/lib/bets'
 import { formattedOdds } from '@/lib/format'
+import { useSettings } from '@/lib/settings'
 import type { BetType, Match } from '@/api/types'
 
 interface Props {
@@ -12,9 +13,13 @@ interface Props {
 
 // The 1 / X / 2 / 1X / X2 / 12 row. Mirrors matches/_buttons.html.erb: a started
 // match locks the pills, the chosen pill is highlighted, and a finished match
-// marks the viewer's own pick as a hit or a miss.
+// marks the viewer's own pick as a hit or a miss. A bet the viewer locked
+// (my_locked) is read-only too, until they unlock it via LockToggle.
 export default function BetGrid({ match, myAnswer, onBet, pending }: Props) {
-  const interactive = Boolean(onBet) && !match.started
+  const { betLock } = useSettings()
+  // The lock only restricts editing when the viewer has the feature enabled.
+  const locked = betLock && match.my_locked
+  const interactive = Boolean(onBet) && !match.started && !locked
   const scored = match.finished ? new Set(winningBets(match.result_a, match.result_b)) : null
 
   return (

--- a/frontend/src/components/LockToggle.tsx
+++ b/frontend/src/components/LockToggle.tsx
@@ -1,0 +1,27 @@
+import { useToggleLock } from '@/api/hooks'
+import { useSettings } from '@/lib/settings'
+import type { Match } from '@/api/types'
+
+// A small padlock that locks the viewer's bet against accidental changes.
+// Opt-in via Settings → Dostępność. Shown only once a bet exists and while the
+// match is still open — after kickoff the bet is frozen anyway. Closed padlock =
+// locked (pills read-only); open = editable. Clicking toggles the lock.
+export default function LockToggle({ match }: { match: Match }) {
+  const { betLock } = useSettings()
+  const toggle = useToggleLock()
+  if (!betLock || !match.my_answer || match.started) return null
+
+  const locked = match.my_locked
+  return (
+    <button
+      type="button"
+      disabled={toggle.isPending}
+      onClick={() => toggle.mutate({ matchId: match.id, locked: !locked })}
+      aria-label={locked ? 'Odblokuj typ' : 'Zablokuj typ'}
+      title={locked ? 'Typ zablokowany — kliknij, aby odblokować' : 'Zablokuj typ przed przypadkową zmianą'}
+      className={`bet-lock${locked ? ' bet-lock-on' : ''}`}
+    >
+      <i className={`fas ${locked ? 'fa-lock' : 'fa-lock-open'}`} aria-hidden="true" />
+    </button>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -96,6 +96,9 @@
   .bet-hit { @apply border-brand bg-brand text-white shadow-sm; }
   /* Finished match: the viewer's pick that missed (light red). */
   .bet-miss { @apply border-danger/40 bg-danger-tint text-danger; }
+  /* Padlock toggle next to the pills (LockToggle); brand-colored when locked. */
+  .bet-lock { @apply inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted transition-colors hover:bg-black/5 hover:text-ink disabled:pointer-events-none disabled:opacity-50; }
+  .bet-lock-on { @apply text-brand hover:text-brand; }
 }
 
 /* "Drzewko mode" (opt-in via Ustawienia → Dostępność): the current user's row in

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -1,46 +1,64 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
+import api from '@/api/client'
+import { useAuth } from '@/auth/AuthContext'
+import type { UserSettings } from '@/api/types'
 
-// Client-side UI preferences, persisted per-device in localStorage (there is no
-// backend for user prefs). Kept as an object so more accessibility options can be
-// added later without touching the storage shape.
+// Client-side view of the per-user UI preferences. The source of truth lives on
+// the backend (User#settings); this context mirrors it in camelCase and writes
+// changes through PATCH /me/settings. Kept as an object so more accessibility
+// options can be added later without touching the storage shape.
 interface Settings {
   // "Drzewko mode": make the current user's nick + position in the ranking easier
   // to find (a prominent "Twoja pozycja" banner with a jump-to-me button).
   drzewkoMode: boolean
+  // Show the padlock that locks a bet against accidental changes. Opt-in: not
+  // everyone wants the extra control, so it is off by default.
+  betLock: boolean
 }
-
-const STORAGE_KEY = 'typerek_settings'
 
 const DEFAULTS: Settings = {
   drzewkoMode: false,
+  betLock: false,
+}
+
+// Map between the server shape (snake_case, the API contract) and ours (camelCase).
+function fromServer(settings: UserSettings | undefined): Settings {
+  return {
+    drzewkoMode: settings?.drzewko_mode ?? DEFAULTS.drzewkoMode,
+    betLock: settings?.bet_lock ?? DEFAULTS.betLock,
+  }
 }
 
 interface SettingsState extends Settings {
   setDrzewkoMode: (value: boolean) => void
+  setBetLock: (value: boolean) => void
 }
 
 const SettingsContext = createContext<SettingsState | undefined>(undefined)
 
-function loadSettings(): Settings {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return DEFAULTS
-    return { ...DEFAULTS, ...(JSON.parse(raw) as Partial<Settings>) }
-  } catch {
-    return DEFAULTS
-  }
-}
-
 export function SettingsProvider({ children }: { children: ReactNode }) {
-  const [settings, setSettings] = useState<Settings>(loadSettings)
+  const { user, refresh } = useAuth()
+  const [settings, setSettings] = useState<Settings>(() => fromServer(user?.settings))
 
+  // Re-sync whenever the signed-in user (and their persisted settings) changes.
   useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
-  }, [settings])
+    setSettings(fromServer(user?.settings))
+  }, [user])
+
+  // Update locally first (snappy toggle), then persist. On failure, fall back to
+  // whatever the server currently holds.
+  const persist = (optimistic: Partial<Settings>, patch: Partial<UserSettings>) => {
+    setSettings((prev) => ({ ...prev, ...optimistic }))
+    api
+      .patch('/me/settings', { settings: patch })
+      .then(() => refresh())
+      .catch(() => setSettings(fromServer(user?.settings)))
+  }
 
   const value: SettingsState = {
     ...settings,
-    setDrzewkoMode: (drzewkoMode) => setSettings((prev) => ({ ...prev, drzewkoMode })),
+    setDrzewkoMode: (drzewkoMode) => persist({ drzewkoMode }, { drzewko_mode: drzewkoMode }),
+    setBetLock: (betLock) => persist({ betLock }, { bet_lock: betLock }),
   }
 
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>

--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@/auth/AuthContext'
 import { ErrorBox, Loading } from '@/components/Status'
 import Flag from '@/components/Flag'
 import BetGrid from '@/components/BetGrid'
+import LockToggle from '@/components/LockToggle'
 import { BET_TYPES, betPillClass, winningBets } from '@/lib/bets'
 import { formatShort, formattedOdds, formattedScore } from '@/lib/format'
 import { useDocumentTitle } from '@/lib/useDocumentTitle'
@@ -68,6 +69,7 @@ export default function MatchPage() {
           <h3 className="flex items-center gap-2">
             <i className="fas fa-user text-brand" aria-hidden="true" /> Twój typ
           </h3>
+          <LockToggle match={match} />
         </div>
         <div className="card-body">
           {!match.started && <p className="mb-3 text-sm text-muted">Wybierz swój typ, klikając w kurs:</p>}

--- a/frontend/src/pages/MatchesPage.tsx
+++ b/frontend/src/pages/MatchesPage.tsx
@@ -4,12 +4,17 @@ import { formatDateLong, groupByDay } from '@/lib/format'
 import { BET_TYPES, BET_LEGEND } from '@/lib/bets'
 import MatchLine from '@/components/MatchLine'
 import BetGrid from '@/components/BetGrid'
+import LockToggle from '@/components/LockToggle'
 import { ErrorBox, Loading } from '@/components/Status'
 import type { BetType, Match } from '@/api/types'
+import { useSettings } from '@/lib/settings'
 import { useDocumentTitle } from '@/lib/useDocumentTitle'
 
 function MatchSection({ matches }: { matches: Match[] }) {
   const placeBet = usePlaceBet()
+  // The padlock column (and the matching legend spacer) only exist when the
+  // viewer enabled the feature; otherwise the layout is the plain pills row.
+  const { betLock } = useSettings()
 
   if (matches.length === 0) {
     return <div className="card card-body text-center text-muted">Brak meczów</div>
@@ -22,13 +27,17 @@ function MatchSection({ matches }: { matches: Match[] }) {
           <div className="card-header">
             <h3 className="text-sm font-bold text-muted">{formatDateLong(group.start)}</h3>
             {/* Legend explaining the 1 / X / 2 / 1X / X2 / 12 symbols, aligned over
-                the bet pills below (hidden on mobile, where the row stacks). */}
-            <div className="hidden w-[340px] grid-cols-6 gap-1.5 sm:grid sm:gap-2">
-              {BET_TYPES.map(([result]) => (
-                <div key={result} className="text-center text-[10px] leading-tight text-muted">
-                  {BET_LEGEND[result]}
-                </div>
-              ))}
+                the bet pills below (hidden on mobile, where the row stacks). The
+                trailing spacer mirrors each row's padlock slot so the columns line up. */}
+            <div className="hidden items-center gap-2 sm:flex">
+              <div className="grid w-[340px] grid-cols-6 gap-1.5 sm:gap-2">
+                {BET_TYPES.map(([result]) => (
+                  <div key={result} className="text-center text-[10px] leading-tight text-muted">
+                    {BET_LEGEND[result]}
+                  </div>
+                ))}
+              </div>
+              {betLock && <div className="w-7 shrink-0" aria-hidden="true" />}
             </div>
           </div>
           <div className="divide-y divide-line/60">
@@ -40,13 +49,23 @@ function MatchSection({ matches }: { matches: Match[] }) {
                 }`}
               >
                 <MatchLine match={match} />
-                <div className="sm:w-[340px]">
-                  <BetGrid
-                    match={match}
-                    myAnswer={match.my_answer}
-                    pending={placeBet.isPending}
-                    onBet={(result: BetType) => placeBet.mutate({ matchId: match.id, result })}
-                  />
+                {/* Pills, plus a fixed padlock slot on the right when the feature is
+                    on. The slot is reserved in every row (lock or empty) so the 6
+                    columns share one offset, matching the legend's trailing spacer. */}
+                <div className="flex items-center gap-2">
+                  <div className="flex-1 sm:w-[340px] sm:flex-none">
+                    <BetGrid
+                      match={match}
+                      myAnswer={match.my_answer}
+                      pending={placeBet.isPending}
+                      onBet={(result: BetType) => placeBet.mutate({ matchId: match.id, result })}
+                    />
+                  </div>
+                  {betLock && (
+                    <div className="w-7 shrink-0">
+                      <LockToggle match={match} />
+                    </div>
+                  )}
                 </div>
               </div>
             ))}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -8,7 +8,7 @@ const TABS = [{ id: 'a11y', label: 'Dostępność' }] as const
 type TabId = (typeof TABS)[number]['id']
 
 export default function SettingsPage() {
-  const { drzewkoMode, setDrzewkoMode } = useSettings()
+  const { drzewkoMode, setDrzewkoMode, betLock, setBetLock } = useSettings()
   const [tab, setTab] = useState<TabId>('a11y')
 
   useDocumentTitle('Ustawienia')
@@ -33,7 +33,7 @@ export default function SettingsPage() {
       </div>
 
       {tab === 'a11y' && (
-        <section className="card">
+        <section className="card divide-y divide-line/60">
           <label className="flex cursor-pointer items-start gap-3 px-4 py-4 sm:px-5">
             <input
               type="checkbox"
@@ -45,6 +45,22 @@ export default function SettingsPage() {
               <span className="block font-semibold text-ink">Drzewko mode</span>
               <span className="block text-muted">
                 Tło Twojego wiersza w rankingu mocno miga, żeby nie dało się go przeoczyć.
+              </span>
+            </span>
+          </label>
+
+          <label className="flex cursor-pointer items-start gap-3 px-4 py-4 sm:px-5">
+            <input
+              type="checkbox"
+              className="mt-0.5 h-5 w-5 shrink-0 accent-brand"
+              checked={betLock}
+              onChange={(event) => setBetLock(event.target.checked)}
+            />
+            <span className="leading-snug">
+              <span className="block font-semibold text-ink">Kłódka na typach</span>
+              <span className="block text-muted">
+                Pokazuje przy każdym typie małą kłódkę, którą możesz zablokować swój wybór, żeby
+                przypadkiem go nie zmienić.
               </span>
             </span>
           </label>

--- a/lib/typerek/answer_locked_error.rb
+++ b/lib/typerek/answer_locked_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Typerek
+  class AnswerLockedError < Error; end
+end

--- a/lib/typerek/set_lock/handler.rb
+++ b/lib/typerek/set_lock/handler.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 module Typerek
-  module MakeBet
+  module SetLock
+    # Locks or unlocks the user's existing bet on a match so it can't be changed
+    # by accident. A locked bet is rejected by MakeBet::Handler.
     class Handler
-      def initialize(match_id:, user_id:, result:)
+      def initialize(match_id:, user_id:, locked:)
         @match_id = match_id
         @user_id = user_id
-        @result = result
+        @locked = ActiveModel::Type::Boolean.new.cast(locked)
       end
 
       def call
@@ -14,13 +16,11 @@ module Typerek
         raise UserNotFoundError, 'Użytkownik nie został znaleziony.' unless user
         raise MatchAlreadyStartedError, 'Mecz już się rozpoczął.' if match.started?
 
-        answer = match.answers.find_or_initialize_by(user_id: user.id)
-        raise AnswerLockedError, 'Typ jest zablokowany.' if answer.locked? && user.bet_lock?
+        answer = match.answers.find_by(user_id: user.id)
+        raise Error, 'Najpierw zatypuj mecz.' unless answer
 
-        answer.update!(result: @result)
+        answer.update!(locked: @locked)
         answer
-      rescue ArgumentError
-        raise Error, 'Nieprawidłowy typ.'
       end
 
       private

--- a/spec/factories/answers.rb
+++ b/spec/factories/answers.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
     match
     user
     result { %i[win_a tie win_b win_tie_a win_tie_b not_tie].sample }
+
+    trait :locked do
+      locked { true }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
     trait :active do
       invitation_accepted_at { Time.current }
     end
+
+    trait :bet_lock do
+      settings { { 'bet_lock' => true } }
+    end
   end
 end

--- a/spec/requests/api/v1/matches_spec.rb
+++ b/spec/requests/api/v1/matches_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'API V1 Matches', type: :request do
         put "/api/v1/matches/#{match.id}/bet", params: { result: 'win_tie_a' }, headers: auth_headers(user), as: :json
 
         expect(response).to have_http_status(:ok)
-        expect(json).to eq('match_id' => match.id, 'result' => 'win_tie_a')
+        expect(json).to eq('match_id' => match.id, 'result' => 'win_tie_a', 'locked' => false)
       end
     end
 
@@ -73,6 +73,38 @@ RSpec.describe 'API V1 Matches', type: :request do
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
+    end
+
+    context 'on a locked answer when the user enabled the bet lock' do
+      let(:user) { create(:user, :active, :bet_lock) }
+      let(:match) { create(:match, :start_in_future) }
+
+      it 'is rejected with 422' do
+        create(:answer, :locked, match: match, user: user, result: 'win_a')
+
+        put "/api/v1/matches/#{match.id}/bet", params: { result: 'win_b' }, headers: auth_headers(user), as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PUT /api/v1/matches/:id/lock' do
+    let(:match) { create(:match, :start_in_future) }
+
+    it 'locks the existing bet' do
+      create(:answer, match: match, user: user, result: 'win_a')
+
+      put "/api/v1/matches/#{match.id}/lock", params: { locked: true }, headers: auth_headers(user), as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json).to eq('match_id' => match.id, 'result' => 'win_a', 'locked' => true)
+    end
+
+    it 'is rejected with 422 when there is no bet yet' do
+      put "/api/v1/matches/#{match.id}/lock", params: { locked: true }, headers: auth_headers(user), as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
     end
   end
 

--- a/spec/requests/api/v1/profile_spec.rb
+++ b/spec/requests/api/v1/profile_spec.rb
@@ -14,8 +14,32 @@ RSpec.describe 'API V1 Profile', type: :request do
       expect(json['standing']).to include('rank' => 1)
     end
 
+    it 'returns the settings with defaults' do
+      get '/api/v1/me', headers: auth_headers(user)
+
+      expect(json['settings']).to eq('drzewko_mode' => false, 'bet_lock' => false)
+    end
+
     it 'returns 401 without a token' do
       get '/api/v1/me'
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'PATCH /api/v1/me/settings' do
+    let(:user) { create(:user, :active) }
+
+    it 'updates a single setting and leaves the rest at their defaults' do
+      patch '/api/v1/me/settings', params: { settings: { bet_lock: true } }, headers: auth_headers(user), as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json['settings']).to eq('drzewko_mode' => false, 'bet_lock' => true)
+      expect(user.reload.bet_lock?).to be(true)
+    end
+
+    it 'returns 401 without a token' do
+      patch '/api/v1/me/settings', params: { settings: { bet_lock: true } }, as: :json
 
       expect(response).to have_http_status(:unauthorized)
     end

--- a/spec/typerek/make_bet/handler_spec.rb
+++ b/spec/typerek/make_bet/handler_spec.rb
@@ -30,6 +30,24 @@ RSpec.describe Typerek::MakeBet::Handler do
       end
     end
 
+    context 'when the existing answer is locked' do
+      it 'raises error when the user enabled the bet lock' do
+        user.update_column(:settings, { 'bet_lock' => true })
+        create(:answer, :locked, match: match, user: user, result: :tie)
+
+        expect do
+          described_class.new(match_id: match.id, user_id: user.id, result: :win_a).call
+        end.to raise_error(Typerek::AnswerLockedError)
+      end
+
+      it 'allows the change when the user disabled the bet lock' do
+        answer = create(:answer, :locked, match: match, user: user, result: :tie)
+        described_class.new(match_id: match.id, user_id: user.id, result: :win_a).call
+
+        expect(answer.reload.result).to eq('win_a')
+      end
+    end
+
     context 'when match is started' do
       it 'raises error' do
         match.update(start: Time.current)

--- a/spec/typerek/set_lock/handler_spec.rb
+++ b/spec/typerek/set_lock/handler_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Typerek::SetLock::Handler do
+  describe '#call' do
+    let(:match) { create(:match, start: 2.days.from_now) }
+    let(:user) { create(:user) }
+
+    context 'when the user has an answer on a not-started match' do
+      it 'locks the answer' do
+        answer = create(:answer, match: match, user: user, result: :win_a)
+        described_class.new(match_id: match.id, user_id: user.id, locked: true).call
+
+        expect(answer.reload.locked).to be(true)
+      end
+
+      it 'unlocks the answer' do
+        answer = create(:answer, :locked, match: match, user: user, result: :win_a)
+        described_class.new(match_id: match.id, user_id: user.id, locked: false).call
+
+        expect(answer.reload.locked).to be(false)
+      end
+    end
+
+    context 'when the user has no answer yet' do
+      it 'raises error' do
+        expect do
+          described_class.new(match_id: match.id, user_id: user.id, locked: true).call
+        end.to raise_error(Typerek::Error)
+      end
+    end
+
+    context 'when match is started' do
+      it 'raises error' do
+        create(:answer, match: match, user: user, result: :win_a)
+        match.update(start: Time.current)
+
+        expect do
+          described_class.new(match_id: match.id, user_id: user.id, locked: true).call
+        end.to raise_error(Typerek::MatchAlreadyStartedError)
+      end
+    end
+
+    context 'when match is not found' do
+      it 'raises error' do
+        expect do
+          described_class.new(match_id: match.id + 1, user_id: user.id, locked: true).call
+        end.to raise_error(Typerek::MatchNotFoundError)
+      end
+    end
+
+    context 'when user is not found' do
+      it 'raises error' do
+        expect do
+          described_class.new(match_id: match.id, user_id: user.id + 1, locked: true).call
+        end.to raise_error(Typerek::UserNotFoundError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Lock a bet against accidental changes via a padlock; the server rejects changes to a locked bet when the user has the feature enabled. Settings (drzewko mode, bet lock) now persist per-user in a jsonb column instead of localStorage, exposed via GET /me and PATCH /me/settings.