### PR TITLE
Fix position charts to use shared positions for ties

### DIFF
--- a/frontend/src/components/RankingBumpChart.tsx
+++ b/frontend/src/components/RankingBumpChart.tsx
@@ -44,21 +44,32 @@ function CustomTooltip({ active, label, payload, matches, userMap, meId, hovered
       ? formattedScore(match.result_a, match.result_b)
       : '–:–'
 
-  const entry = hoveredUserId ? payload.find((p) => p.dataKey === hoveredUserId) : null
+  const hoveredEntry = hoveredUserId ? payload.find((p) => p.dataKey === hoveredUserId) : null
+  const focusPosition = hoveredEntry?.value
+  const tiedEntries = focusPosition != null
+    ? payload.filter((p) => p.value === focusPosition)
+    : hoveredEntry ? [hoveredEntry] : []
 
   return (
-    <div className="card card-body w-48 py-2 text-xs shadow-lg">
+    <div className="card card-body w-52 py-2 text-xs shadow-lg">
       <p className="mb-1 font-semibold text-ink">
         Mecz #{label}: {match.team_a} {score} {match.team_b}
       </p>
       <p className="text-muted">{formatDateLong(match.start)}</p>
-      {entry && (
-        <div className="mt-2 flex items-center gap-1.5 border-t border-line pt-2">
-          <span className="w-4 text-right font-bold tabular-nums text-ink">{entry.value}.</span>
-          <span className="inline-block h-2 w-2.5 shrink-0 rounded-sm" style={{ backgroundColor: entry.stroke }} />
-          <span className={`truncate ${entry.dataKey === String(meId) ? 'font-semibold text-brand' : 'text-ink'}`}>
-            {userMap.get(entry.dataKey) ?? '—'}
-          </span>
+      {tiedEntries.length > 0 && (
+        <div className="mt-2 space-y-1 border-t border-line pt-2">
+          {tiedEntries.map((entry, i) => (
+            <div key={entry.dataKey} className="flex items-center gap-1.5">
+              {i === 0 && (
+                <span className="w-4 text-right font-bold tabular-nums text-ink">{entry.value}.</span>
+              )}
+              {i > 0 && <span className="w-4" />}
+              <span className="inline-block h-2 w-2.5 shrink-0 rounded-sm" style={{ backgroundColor: entry.stroke }} />
+              <span className={`truncate ${entry.dataKey === String(meId) ? 'font-semibold text-brand' : 'text-ink'}`}>
+                {userMap.get(entry.dataKey) ?? '—'}
+              </span>
+            </div>
+          ))}
         </div>
       )}
     </div>
@@ -151,7 +162,7 @@ export default function RankingBumpChart({ enabled }: Props) {
   const totalUsers = series.length
   const chartWidth = Math.max(matches.length * COL_PX, 600)
   const desktopChartHeight = Math.max(DESKTOP_CHART_MIN_HEIGHT, totalUsers * DESKTOP_CHART_HEIGHT_PER_USER)
-  const yTicks = Array.from({ length: totalUsers }, (_, i) => i + 1)
+  const yTicks = Array.from(new Set(series.flatMap((s) => s.positions))).sort((a, b) => a - b)
 
   const toggleHighlight = (id: number) => setHighlightedId((prev) => (prev === id ? null : id))
 

--- a/frontend/src/components/UserPositionChart.tsx
+++ b/frontend/src/components/UserPositionChart.tsx
@@ -66,7 +66,7 @@ export default function UserPositionChart({ userId }: Props) {
 
   const totalUsers = series.length
   const chartWidth = Math.max(matches.length * COL_PX, 300)
-  const yTicks = Array.from({ length: totalUsers }, (_, i) => i + 1)
+  const yTicks = Array.from(new Set(series.flatMap((s) => s.positions))).sort((a, b) => a - b)
 
   const rows = matches.map((_, i) => ({
     x: i + 1,

--- a/frontend/src/components/UserPositionChart.tsx
+++ b/frontend/src/components/UserPositionChart.tsx
@@ -109,7 +109,7 @@ export default function UserPositionChart({ userId }: Props) {
                   />
                   <YAxis
                     reversed
-                    domain={[1, totalUsers]}
+                    domain={[yTicks[0] ?? 1, yTicks[yTicks.length - 1] ?? totalUsers]}
                     ticks={yTicks}
                     allowDecimals={false}
                     width={24}

--- a/lib/typerek/ranking/history.rb
+++ b/lib/typerek/ranking/history.rb
@@ -55,8 +55,10 @@ module Typerek
           end
 
           ordered = sort_users(users, cumulative)
-          ordered.each_with_index do |user, idx|
-            series_data[user.id][:positions] << idx + 1
+          ranked_points = ordered.map { |u| cumulative[u.id] }
+          ordered.each do |user|
+            position = ranked_points.index(cumulative[user.id]) + 1
+            series_data[user.id][:positions] << position
             series_data[user.id][:points]    << cumulative[user.id]
           end
         end

--- a/spec/typerek/ranking/history_spec.rb
+++ b/spec/typerek/ranking/history_spec.rb
@@ -46,19 +46,25 @@ RSpec.describe Typerek::Ranking::History do
       expect(bob_series.points[1]).to eq(2.0)
     end
 
-    it 'assigns unique sequential positions (no shared positions even on equal points)' do
-      amy = active_user('amy') # alphabetically first -> lower position number (higher rank)
+    it 'assigns shared positions for tied users, consistent with Ranking::Query' do
+      amy = active_user('amy')
+      bob = active_user('bob')
       zoe = active_user('zoe')
 
+      # amy and bob tie on match1 (both correct); zoe gets 0
       create(:answer, match: match1, user: amy, result: :win_a)
-      create(:answer, match: match1, user: zoe, result: :win_a)
+      create(:answer, match: match1, user: bob, result: :win_a)
+      create(:answer, match: match1, user: zoe, result: :tie)
 
       result = described_class.new.call
       amy_series = result.series.find { |s| s.user.username == 'amy' }
+      bob_series = result.series.find { |s| s.user.username == 'bob' }
       zoe_series = result.series.find { |s| s.user.username == 'zoe' }
 
+      # amy and bob are tied -> both get position 1; zoe is third -> position 3
       expect(amy_series.positions[0]).to eq(1)
-      expect(zoe_series.positions[0]).to eq(2)
+      expect(bob_series.positions[0]).to eq(1)
+      expect(zoe_series.positions[0]).to eq(3)
     end
 
     it 'excludes users who have not accepted their invitation' do


### PR DESCRIPTION
## Summary

- `Ranking::History` was assigning sequential positions (`1, 2, 3`) via `each_with_index`, while `Ranking::Query` uses shared positions (`1, 1, 3`). The chart now matches what the live ranking displays.
- Y-axis ticks in both charts are now derived from positions that actually appear in the data — skipped positions (e.g. `2` when two users share `1st`) no longer show as empty tick rows.
- The bump chart tooltip now lists all users sharing the same position when hovering a tied line.

## Test Plan

- [ ] Verify `rspec spec/typerek/ranking/history_spec.rb` passes — specifically the new `assigns shared positions for tied users` example
- [ ] In the app, check the ranking bump chart when two users have equal points — both lines should sit on the same Y position and the tooltip should show both names
- [ ] Confirm Y-axis only shows positions that exist in the data (no ghost tick rows)