### PR TITLE
Drop "Dostępność" tab and show per-setting usage counts

### DIFF
--- a/app/controllers/api/v1/profile_controller.rb
+++ b/app/controllers/api/v1/profile_controller.rb
@@ -7,6 +7,10 @@ module Api
         render json: CurrentUserSerializer.call(current_user)
       end
 
+      def settings_stats
+        render json: User.settings_counts
+      end
+
       def update_settings
         # Persist only the settings bag, skipping validations: the User model
         # requires a password on every update (it is set during invitation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,15 @@ class User < ApplicationRecord
     update(params.merge(invitation_accepted_at: DateTime.now))
   end
 
+  # Number of users with each setting switched on, keyed by the setting name.
+  # Powers the "Włączone przez N osób" hint on the settings screen. Users who have
+  # never toggled anything store no key and so are naturally counted as "off".
+  def self.settings_counts
+    SETTINGS_DEFAULTS.keys.index_with do |key|
+      where("settings ->> ? = 'true'", key).count
+    end
+  end
+
   def settings_with_defaults
     SETTINGS_DEFAULTS.merge(settings || {})
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       post 'auth/login', to: 'auth#login'
       post 'auth/logout', to: 'auth#logout'
       get 'me', to: 'profile#show'
+      get 'me/settings/stats', to: 'profile#settings_stats'
       patch 'me/settings', to: 'profile#update_settings'
 
       resources :matches, only: %i[index show update] do

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,17 +1,48 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import api from '@/api/client'
+import { useAuth } from '@/auth/AuthContext'
 import { useSettings } from '@/lib/settings'
 import { useDocumentTitle } from '@/lib/useDocumentTitle'
 
-// Tabs are kept as an array so more settings groups can be added later; for now
-// "Dostępność" is the only one.
-const TABS = [{ id: 'a11y', label: 'Dostępność' }] as const
-type TabId = (typeof TABS)[number]['id']
+// Number of users with each setting switched on, keyed by the server setting name.
+type SettingsStats = Record<string, number>
+
+// Polish accusative of "osoba" for the "Włączone przez N osób" hint:
+// 1 → osobę, 2–4 (but not 12–14) → osoby, otherwise → osób.
+function peopleAccusative(count: number): string {
+  if (count === 1) return '1 osobę'
+  const mod10 = count % 10
+  const mod100 = count % 100
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return `${count} osoby`
+  return `${count} osób`
+}
+
+function UsageHint({ count }: { count: number | undefined }) {
+  if (count === undefined) return null
+  const text = count === 0 ? 'Jeszcze nikt tego nie włączył' : `Włączone przez ${peopleAccusative(count)}`
+  return (
+    <span className="mt-1.5 inline-flex items-center gap-1.5 text-xs font-medium text-muted">
+      <i className="fas fa-user-group" aria-hidden="true" /> {text}
+    </span>
+  )
+}
 
 export default function SettingsPage() {
   const { drzewkoMode, setDrzewkoMode, betLock, setBetLock } = useSettings()
-  const [tab, setTab] = useState<TabId>('a11y')
+  const { user } = useAuth()
+  const [stats, setStats] = useState<SettingsStats | null>(null)
 
   useDocumentTitle('Ustawienia')
+
+  // How many people use each setting. Keyed on `user` (not the optimistic toggle
+  // state) so the refetch runs only after a save is confirmed and `refresh()` has
+  // updated the user — otherwise it would race the PATCH and read a stale count.
+  useEffect(() => {
+    api
+      .get<SettingsStats>('/me/settings/stats')
+      .then(setStats)
+      .catch(() => setStats(null))
+  }, [user])
 
   return (
     <>
@@ -19,53 +50,40 @@ export default function SettingsPage() {
         <i className="fas fa-cog text-brand" aria-hidden="true" /> Ustawienia
       </h1>
 
-      <div className="mb-5 flex border-b border-line">
-        {TABS.map((item) => (
-          <button
-            key={item.id}
-            type="button"
-            onClick={() => setTab(item.id)}
-            className={`tab${tab === item.id ? ' tab-active' : ''}`}
-          >
-            {item.label}
-          </button>
-        ))}
-      </div>
-
-      {tab === 'a11y' && (
-        <section className="card divide-y divide-line/60">
-          <label className="flex cursor-pointer items-start gap-3 px-4 py-4 sm:px-5">
-            <input
-              type="checkbox"
-              className="mt-0.5 h-5 w-5 shrink-0 accent-brand"
-              checked={drzewkoMode}
-              onChange={(event) => setDrzewkoMode(event.target.checked)}
-            />
-            <span className="leading-snug">
-              <span className="block font-semibold text-ink">Drzewko mode</span>
-              <span className="block text-muted">
-                Tło Twojego wiersza w rankingu mocno miga, żeby nie dało się go przeoczyć.
-              </span>
+      <section className="card divide-y divide-line/60">
+        <label className="flex cursor-pointer items-start gap-3 px-4 py-4 sm:px-5">
+          <input
+            type="checkbox"
+            className="mt-0.5 h-5 w-5 shrink-0 accent-brand"
+            checked={drzewkoMode}
+            onChange={(event) => setDrzewkoMode(event.target.checked)}
+          />
+          <span className="leading-snug">
+            <span className="block font-semibold text-ink">Drzewko mode</span>
+            <span className="block text-muted">
+              Tło Twojego wiersza w rankingu mocno miga, żeby nie dało się go przeoczyć.
             </span>
-          </label>
+            <UsageHint count={stats?.drzewko_mode} />
+          </span>
+        </label>
 
-          <label className="flex cursor-pointer items-start gap-3 px-4 py-4 sm:px-5">
-            <input
-              type="checkbox"
-              className="mt-0.5 h-5 w-5 shrink-0 accent-brand"
-              checked={betLock}
-              onChange={(event) => setBetLock(event.target.checked)}
-            />
-            <span className="leading-snug">
-              <span className="block font-semibold text-ink">Kłódka na typach</span>
-              <span className="block text-muted">
-                Pokazuje przy każdym typie małą kłódkę, którą możesz zablokować swój wybór, żeby
-                przypadkiem go nie zmienić.
-              </span>
+        <label className="flex cursor-pointer items-start gap-3 px-4 py-4 sm:px-5">
+          <input
+            type="checkbox"
+            className="mt-0.5 h-5 w-5 shrink-0 accent-brand"
+            checked={betLock}
+            onChange={(event) => setBetLock(event.target.checked)}
+          />
+          <span className="leading-snug">
+            <span className="block font-semibold text-ink">Kłódka na typach</span>
+            <span className="block text-muted">
+              Pokazuje przy każdym typie małą kłódkę, którą możesz zablokować swój wybór, żeby
+              przypadkiem go nie zmienić.
             </span>
-          </label>
-        </section>
-      )}
+            <UsageHint count={stats?.bet_lock} />
+          </span>
+        </label>
+      </section>
     </>
   )
 }

--- a/spec/requests/api/v1/profile_spec.rb
+++ b/spec/requests/api/v1/profile_spec.rb
@@ -27,6 +27,26 @@ RSpec.describe 'API V1 Profile', type: :request do
     end
   end
 
+  describe 'GET /api/v1/me/settings/stats' do
+    let(:user) { create(:user, :active) }
+
+    it 'returns how many users have each setting enabled' do
+      create(:user, :active, settings: { 'drzewko_mode' => true, 'bet_lock' => true })
+      create(:user, :active, settings: { 'drzewko_mode' => true })
+
+      get '/api/v1/me/settings/stats', headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(json).to eq('drzewko_mode' => 2, 'bet_lock' => 1)
+    end
+
+    it 'returns 401 without a token' do
+      get '/api/v1/me/settings/stats'
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
   describe 'PATCH /api/v1/me/settings' do
     let(:user) { create(:user, :active) }
 


### PR DESCRIPTION
Flatten the settings screen: the two toggles no longer live under a single "Dostępność" category, so the tab UI is gone.

Add GET /api/v1/me/settings/stats (User.settings_counts) and render "Włączone przez N osób" under each setting. The count refetch is keyed on the auth user so it runs only after a save is confirmed, avoiding a race with the PATCH that left the count one step behind.