### PR TITLE
Show dziś/jutro day badges and countdown timer on match lines

### DIFF
--- a/frontend/src/components/BetGrid.tsx
+++ b/frontend/src/components/BetGrid.tsx
@@ -9,17 +9,21 @@ interface Props {
   // When omitted (or the match has started) the grid is read-only.
   onBet?: (result: BetType) => void
   pending?: boolean
+  // Lets the parent pass a locally-derived started value so the grid locks at
+  // kickoff without waiting for a page refresh.
+  started?: boolean
 }
 
 // The 1 / X / 2 / 1X / X2 / 12 row. Mirrors matches/_buttons.html.erb: a started
 // match locks the pills, the chosen pill is highlighted, and a finished match
 // marks the viewer's own pick as a hit or a miss. A bet the viewer locked
 // (my_locked) is read-only too, until they unlock it via LockToggle.
-export default function BetGrid({ match, myAnswer, onBet, pending }: Props) {
+export default function BetGrid({ match, myAnswer, onBet, pending, started }: Props) {
   const { betLock } = useSettings()
+  const hasStarted = started ?? match.started
   // The lock only restricts editing when the viewer has the feature enabled.
   const locked = betLock && match.my_locked
-  const interactive = Boolean(onBet) && !match.started && !locked
+  const interactive = Boolean(onBet) && !hasStarted && !locked
   const scored = match.finished ? new Set(winningBets(match.result_a, match.result_b)) : null
 
   return (

--- a/frontend/src/components/MatchLine.tsx
+++ b/frontend/src/components/MatchLine.tsx
@@ -29,8 +29,8 @@ function Countdown({ start }: { start: string }) {
 
   const urgent = remaining < 30 * 60 * 1000
   return (
-    <span className={`tabular-nums text-[10px] font-bold leading-none ${urgent ? 'text-amber-600' : 'text-muted'}`}>
-      {formatCountdown(remaining)}
+    <span className={`text-[10px] font-bold leading-none ${urgent ? 'text-amber-600' : 'text-muted'}`}>
+      za <span className="tabular-nums">{formatCountdown(remaining)}</span>
     </span>
   )
 }
@@ -41,7 +41,7 @@ export default function MatchLine({ match }: { match: Match }) {
   const live = match.started && !match.finished
   return (
     <Link to={`/matches/${match.id}`} className="group flex items-center gap-2 sm:flex-1 sm:gap-3">
-      <span className="flex w-11 shrink-0 flex-col gap-0.5">
+      <span className="flex w-14 shrink-0 flex-col gap-0.5">
         <span className="text-sm font-semibold tabular-nums text-muted">{formatTime(match.start)}</span>
         {live && (
           <span className="inline-flex items-center gap-1 text-[10px] font-bold leading-none text-amber-600">

--- a/frontend/src/components/MatchLine.tsx
+++ b/frontend/src/components/MatchLine.tsx
@@ -1,7 +1,39 @@
 import { Link } from 'react-router-dom'
+import { useEffect, useState } from 'react'
 import Flag from './Flag'
 import { formatTime, formattedScore } from '@/lib/format'
 import type { Match } from '@/api/types'
+
+const SIX_HOURS = 6 * 60 * 60 * 1000
+
+function formatCountdown(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000)
+  const h = Math.floor(totalSeconds / 3600)
+  const m = Math.floor((totalSeconds % 3600) / 60)
+  const s = totalSeconds % 60
+  const pad = (n: number) => String(n).padStart(2, '0')
+  if (h > 0) return `${h}h ${pad(m)}m`
+  return `${pad(m)}:${pad(s)}`
+}
+
+function Countdown({ start }: { start: string }) {
+  const [remaining, setRemaining] = useState(() => new Date(start).getTime() - Date.now())
+
+  useEffect(() => {
+    const tick = () => setRemaining(new Date(start).getTime() - Date.now())
+    const id = setInterval(tick, 1000)
+    return () => clearInterval(id)
+  }, [start])
+
+  if (remaining <= 0 || remaining > SIX_HOURS) return null
+
+  const urgent = remaining < 30 * 60 * 1000
+  return (
+    <span className={`tabular-nums text-[10px] font-bold leading-none ${urgent ? 'text-amber-600' : 'text-muted'}`}>
+      {formatCountdown(remaining)}
+    </span>
+  )
+}
 
 // Clickable match line: time on the left, then "TeamA <flag>  score  <flag> TeamB"
 // with the score centered. Mirrors matches/_match_line.html.erb.
@@ -17,6 +49,7 @@ export default function MatchLine({ match }: { match: Match }) {
             Trwa
           </span>
         )}
+        {!match.started && <Countdown start={match.start} />}
       </span>
       <span className="flex flex-1 items-center justify-center gap-2 sm:gap-3">
         <span className="flex-1 text-right font-semibold text-ink group-hover:text-brand">

--- a/frontend/src/components/MatchLine.tsx
+++ b/frontend/src/components/MatchLine.tsx
@@ -29,7 +29,7 @@ function Countdown({ start }: { start: string }) {
 
   const urgent = remaining < 30 * 60 * 1000
   return (
-    <span className={`text-[10px] font-bold leading-none ${urgent ? 'text-amber-600' : 'text-muted'}`}>
+    <span className={`inline-block rounded-full px-1.5 py-0.5 text-[10px] font-semibold leading-none tracking-wide ${urgent ? 'bg-amber-100 text-amber-600' : 'bg-sky-100 text-sky-600'}`}>
       za <span className="tabular-nums">{formatCountdown(remaining)}</span>
     </span>
   )

--- a/frontend/src/components/MatchLine.tsx
+++ b/frontend/src/components/MatchLine.tsx
@@ -6,6 +6,22 @@ import type { Match } from '@/api/types'
 
 const SIX_HOURS = 6 * 60 * 60 * 1000
 
+// Tracks whether a match has started, flipping to true at kickoff time without
+// needing a page refresh. Safe to call from multiple components for the same match.
+export function useLocalStarted(match: Match): boolean {
+  const [started, setStarted] = useState(
+    () => match.started || Date.now() >= new Date(match.start).getTime(),
+  )
+  useEffect(() => {
+    if (started) return
+    const ms = new Date(match.start).getTime() - Date.now()
+    if (ms <= 0) { setStarted(true); return }
+    const id = setTimeout(() => setStarted(true), ms)
+    return () => clearTimeout(id)
+  }, [match.start, started])
+  return started
+}
+
 function formatCountdown(ms: number): string {
   const totalSeconds = Math.floor(ms / 1000)
   const h = Math.floor(totalSeconds / 3600)
@@ -38,7 +54,8 @@ function Countdown({ start }: { start: string }) {
 // Clickable match line: time on the left, then "TeamA <flag>  score  <flag> TeamB"
 // with the score centered. Mirrors matches/_match_line.html.erb.
 export default function MatchLine({ match }: { match: Match }) {
-  const live = match.started && !match.finished
+  const localStarted = useLocalStarted(match)
+  const live = localStarted && !match.finished
   return (
     <Link to={`/matches/${match.id}`} className="group flex items-center gap-2 sm:flex-1 sm:gap-3">
       <span className="flex w-14 shrink-0 flex-col gap-0.5">
@@ -49,7 +66,7 @@ export default function MatchLine({ match }: { match: Match }) {
             Trwa
           </span>
         )}
-        {!match.started && <Countdown start={match.start} />}
+        {!localStarted && <Countdown start={match.start} />}
       </span>
       <span className="flex flex-1 items-center justify-center gap-2 sm:gap-3">
         <span className="flex-1 text-right font-semibold text-ink group-hover:text-brand">

--- a/frontend/src/components/MatchLine.tsx
+++ b/frontend/src/components/MatchLine.tsx
@@ -29,7 +29,7 @@ function Countdown({ start }: { start: string }) {
 
   const urgent = remaining < 30 * 60 * 1000
   return (
-    <span className={`inline-block rounded-full px-1.5 py-0.5 text-[10px] font-semibold leading-none tracking-wide ${urgent ? 'bg-amber-100 text-amber-600' : 'bg-sky-100 text-sky-600'}`}>
+    <span className={`text-[10px] font-bold leading-none ${urgent ? 'text-amber-600' : 'text-muted'}`}>
       za <span className="tabular-nums">{formatCountdown(remaining)}</span>
     </span>
   )

--- a/frontend/src/components/MatchLine.tsx
+++ b/frontend/src/components/MatchLine.tsx
@@ -1,26 +1,13 @@
 import { Link } from 'react-router-dom'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Flag from './Flag'
 import { formatTime, formattedScore } from '@/lib/format'
+import { useLocalStarted } from '@/lib/useLocalStarted'
 import type { Match } from '@/api/types'
 
-const SIX_HOURS = 6 * 60 * 60 * 1000
+export { useLocalStarted } from '@/lib/useLocalStarted'
 
-// Tracks whether a match has started, flipping to true at kickoff time without
-// needing a page refresh. Safe to call from multiple components for the same match.
-export function useLocalStarted(match: Match): boolean {
-  const [started, setStarted] = useState(
-    () => match.started || Date.now() >= new Date(match.start).getTime(),
-  )
-  useEffect(() => {
-    if (started) return
-    const ms = new Date(match.start).getTime() - Date.now()
-    if (ms <= 0) { setStarted(true); return }
-    const id = setTimeout(() => setStarted(true), ms)
-    return () => clearTimeout(id)
-  }, [match.start, started])
-  return started
-}
+const SIX_HOURS = 6 * 60 * 60 * 1000
 
 function formatCountdown(ms: number): string {
   const totalSeconds = Math.floor(ms / 1000)
@@ -33,13 +20,14 @@ function formatCountdown(ms: number): string {
 }
 
 function Countdown({ start }: { start: string }) {
-  const [remaining, setRemaining] = useState(() => new Date(start).getTime() - Date.now())
+  const startMs = useMemo(() => new Date(start).getTime(), [start])
+  const [remaining, setRemaining] = useState(() => startMs - Date.now())
 
   useEffect(() => {
-    const tick = () => setRemaining(new Date(start).getTime() - Date.now())
+    const tick = () => setRemaining(startMs - Date.now())
     const id = setInterval(tick, 1000)
     return () => clearInterval(id)
-  }, [start])
+  }, [startMs])
 
   if (remaining <= 0 || remaining > SIX_HOURS) return null
 
@@ -53,8 +41,11 @@ function Countdown({ start }: { start: string }) {
 
 // Clickable match line: time on the left, then "TeamA <flag>  score  <flag> TeamB"
 // with the score centered. Mirrors matches/_match_line.html.erb.
-export default function MatchLine({ match }: { match: Match }) {
-  const localStarted = useLocalStarted(match)
+// `started` can be passed from a parent that already holds the value to avoid a
+// duplicate hook call; when omitted, the component computes it internally.
+export default function MatchLine({ match, started }: { match: Match; started?: boolean }) {
+  const internal = useLocalStarted(match)
+  const localStarted = started ?? internal
   const live = localStarted && !match.finished
   return (
     <Link to={`/matches/${match.id}`} className="group flex items-center gap-2 sm:flex-1 sm:gap-3">

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -27,6 +27,20 @@ export function formatDateLong(iso: string): string {
   return text.charAt(0).toUpperCase() + text.slice(1)
 }
 
+// Returns "dziś" or "jutro" when the ISO date falls on today/tomorrow (local
+// time), otherwise null — lets callers render a visual badge.
+export function relativeDay(iso: string): 'dziś' | 'jutro' | null {
+  const sameDay = (a: Date, b: Date) =>
+    a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
+  const date = new Date(iso)
+  const today = new Date()
+  const tomorrow = new Date()
+  tomorrow.setDate(today.getDate() + 1)
+  if (sameDay(date, today)) return 'dziś'
+  if (sameDay(date, tomorrow)) return 'jutro'
+  return null
+}
+
 // ISO timestamp -> value for an <input type="datetime-local"> (local wall time).
 export function toDateTimeLocalValue(iso: string): string {
   const date = new Date(iso)

--- a/frontend/src/lib/useLocalStarted.ts
+++ b/frontend/src/lib/useLocalStarted.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react'
+import type { Match } from '@/api/types'
+
+// Tracks whether a match has started, flipping to true at kickoff time without
+// needing a page refresh.
+export function useLocalStarted(match: Match): boolean {
+  const [started, setStarted] = useState(
+    () => match.started || Date.now() >= new Date(match.start).getTime(),
+  )
+  useEffect(() => {
+    if (started) return
+    const ms = new Date(match.start).getTime() - Date.now()
+    if (ms <= 0) { setStarted(true); return }
+    const id = setTimeout(() => setStarted(true), ms)
+    return () => clearTimeout(id)
+  }, [match.start, started])
+  return started
+}

--- a/frontend/src/pages/MatchesPage.tsx
+++ b/frontend/src/pages/MatchesPage.tsx
@@ -2,7 +2,8 @@ import { useSearchParams } from 'react-router-dom'
 import { useMatches, usePlaceBet } from '@/api/hooks'
 import { formatDateLong, groupByDay, relativeDay } from '@/lib/format'
 import { BET_TYPES, BET_LEGEND } from '@/lib/bets'
-import MatchLine, { useLocalStarted } from '@/components/MatchLine'
+import MatchLine from '@/components/MatchLine'
+import { useLocalStarted } from '@/lib/useLocalStarted'
 import BetGrid from '@/components/BetGrid'
 import LockToggle from '@/components/LockToggle'
 import { ErrorBox, Loading } from '@/components/Status'
@@ -26,7 +27,7 @@ function MatchRow({ match }: { match: Match }) {
     <div
       className={`flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-5${live ? ' bg-amber-50/70' : ''}`}
     >
-      <MatchLine match={match} />
+      <MatchLine match={match} started={localStarted} />
       {/* Pills, plus a fixed padlock slot on the right when the feature is
           on. The slot is reserved in every row (lock or empty) so the 6
           columns share one offset, matching the legend's trailing spacer. */}

--- a/frontend/src/pages/MatchesPage.tsx
+++ b/frontend/src/pages/MatchesPage.tsx
@@ -2,7 +2,7 @@ import { useSearchParams } from 'react-router-dom'
 import { useMatches, usePlaceBet } from '@/api/hooks'
 import { formatDateLong, groupByDay, relativeDay } from '@/lib/format'
 import { BET_TYPES, BET_LEGEND } from '@/lib/bets'
-import MatchLine from '@/components/MatchLine'
+import MatchLine, { useLocalStarted } from '@/components/MatchLine'
 import BetGrid from '@/components/BetGrid'
 import LockToggle from '@/components/LockToggle'
 import { ErrorBox, Loading } from '@/components/Status'
@@ -17,10 +17,39 @@ function DayBadge({ iso }: { iso: string }) {
   return <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold tracking-wide ${cls}`}>{label}</span>
 }
 
-function MatchSection({ matches }: { matches: Match[] }) {
+function MatchRow({ match }: { match: Match }) {
   const placeBet = usePlaceBet()
-  // The padlock column (and the matching legend spacer) only exist when the
-  // viewer enabled the feature; otherwise the layout is the plain pills row.
+  const { betLock } = useSettings()
+  const localStarted = useLocalStarted(match)
+  const live = localStarted && !match.finished
+  return (
+    <div
+      className={`flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-5${live ? ' bg-amber-50/70' : ''}`}
+    >
+      <MatchLine match={match} />
+      {/* Pills, plus a fixed padlock slot on the right when the feature is
+          on. The slot is reserved in every row (lock or empty) so the 6
+          columns share one offset, matching the legend's trailing spacer. */}
+      <div className="flex items-center gap-2">
+        <div className="flex-1 sm:w-[340px] sm:flex-none">
+          <BetGrid
+            match={match}
+            myAnswer={match.my_answer}
+            pending={placeBet.isPending}
+            onBet={(result: BetType) => placeBet.mutate({ matchId: match.id, result })}
+          />
+        </div>
+        {betLock && (
+          <div className="w-7 shrink-0">
+            <LockToggle match={match} />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function MatchSection({ matches }: { matches: Match[] }) {
   const { betLock } = useSettings()
 
   if (matches.length === 0) {
@@ -52,32 +81,7 @@ function MatchSection({ matches }: { matches: Match[] }) {
           </div>
           <div className="divide-y divide-line/60">
             {group.items.map((match) => (
-              <div
-                key={match.id}
-                className={`flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-5${
-                  match.started && !match.finished ? ' bg-amber-50/70' : ''
-                }`}
-              >
-                <MatchLine match={match} />
-                {/* Pills, plus a fixed padlock slot on the right when the feature is
-                    on. The slot is reserved in every row (lock or empty) so the 6
-                    columns share one offset, matching the legend's trailing spacer. */}
-                <div className="flex items-center gap-2">
-                  <div className="flex-1 sm:w-[340px] sm:flex-none">
-                    <BetGrid
-                      match={match}
-                      myAnswer={match.my_answer}
-                      pending={placeBet.isPending}
-                      onBet={(result: BetType) => placeBet.mutate({ matchId: match.id, result })}
-                    />
-                  </div>
-                  {betLock && (
-                    <div className="w-7 shrink-0">
-                      <LockToggle match={match} />
-                    </div>
-                  )}
-                </div>
-              </div>
+              <MatchRow key={match.id} match={match} />
             ))}
           </div>
         </section>

--- a/frontend/src/pages/MatchesPage.tsx
+++ b/frontend/src/pages/MatchesPage.tsx
@@ -37,6 +37,7 @@ function MatchRow({ match }: { match: Match }) {
             match={match}
             myAnswer={match.my_answer}
             pending={placeBet.isPending}
+            started={localStarted}
             onBet={(result: BetType) => placeBet.mutate({ matchId: match.id, result })}
           />
         </div>

--- a/frontend/src/pages/MatchesPage.tsx
+++ b/frontend/src/pages/MatchesPage.tsx
@@ -1,6 +1,6 @@
 import { useSearchParams } from 'react-router-dom'
 import { useMatches, usePlaceBet } from '@/api/hooks'
-import { formatDateLong, groupByDay } from '@/lib/format'
+import { formatDateLong, groupByDay, relativeDay } from '@/lib/format'
 import { BET_TYPES, BET_LEGEND } from '@/lib/bets'
 import MatchLine from '@/components/MatchLine'
 import BetGrid from '@/components/BetGrid'
@@ -9,6 +9,13 @@ import { ErrorBox, Loading } from '@/components/Status'
 import type { BetType, Match } from '@/api/types'
 import { useSettings } from '@/lib/settings'
 import { useDocumentTitle } from '@/lib/useDocumentTitle'
+
+function DayBadge({ iso }: { iso: string }) {
+  const label = relativeDay(iso)
+  if (!label) return null
+  const cls = label === 'dziś' ? 'bg-brand/15 text-brand' : 'bg-sky-100 text-sky-600'
+  return <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold tracking-wide ${cls}`}>{label}</span>
+}
 
 function MatchSection({ matches }: { matches: Match[] }) {
   const placeBet = usePlaceBet()
@@ -25,7 +32,10 @@ function MatchSection({ matches }: { matches: Match[] }) {
       {groupByDay(matches).map((group) => (
         <section key={group.start} className="card overflow-hidden">
           <div className="card-header">
-            <h3 className="text-sm font-bold text-muted">{formatDateLong(group.start)}</h3>
+            <h3 className="flex items-center gap-2 text-sm font-bold text-muted">
+              {formatDateLong(group.start)}
+              <DayBadge iso={group.start} />
+            </h3>
             {/* Legend explaining the 1 / X / 2 / 1X / X2 / 12 symbols, aligned over
                 the bet pills below (hidden on mobile, where the row stacks). The
                 trailing spacer mirrors each row's padlock slot so the columns line up. */}


### PR DESCRIPTION
## Summary
- Date section headers show a **dziś** (brand) or **jutro** (sky-blue) pill badge when the group falls on today or tomorrow
- Match lines show a live **za Xh MMm / za MM:SS** countdown for matches starting within 6 hours; turns amber under 30 min

## Test Plan
- [ ] Today's match group header shows the "dziś" badge
- [ ] Tomorrow's match group header shows the "jutro" badge
- [ ] A match starting within 6h shows "za Xh MMm" ticking down
- [ ] Under 30 min the countdown text turns amber
- [ ] Past and future dates/matches beyond the thresholds show nothing extra