### PR TITLE
Add an admin button to trigger the reminder job

### DIFF
--- a/app/controllers/api/v1/push/reminders_controller.rb
+++ b/app/controllers/api/v1/push/reminders_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Push
+      # Admin-only: manually run the unbet-match reminder job — the very same one the
+      # scheduler fires every 15 minutes. Handy for testing the reminder path without
+      # waiting for the timer. It stays idempotent (match_reminders), so triggering it
+      # repeatedly won't double-send.
+      class RemindersController < BaseController
+        def create
+          authorize! :broadcast, :push
+
+          SendMatchRemindersJob.perform_later
+          head :accepted
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,12 +24,14 @@ Rails.application.routes.draw do
 
       get 'bets', to: 'bets#index'
 
-      # Web Push: a device lists/registers/removes its subscription; admins broadcast.
+      # Web Push: a device lists/registers/removes its subscription; admins broadcast
+      # and can manually trigger the unbet-match reminder job.
       namespace :push do
         get 'subscriptions', to: 'subscriptions#index'
         post 'subscriptions', to: 'subscriptions#create'
         delete 'subscriptions', to: 'subscriptions#destroy'
         post 'broadcast', to: 'broadcasts#create'
+        post 'reminders', to: 'reminders#create'
       end
 
       resources :users, only: %i[index create show destroy] do

--- a/frontend/src/pages/AdminPushPage.tsx
+++ b/frontend/src/pages/AdminPushPage.tsx
@@ -12,6 +12,7 @@ export default function AdminPushPage() {
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
   const [sending, setSending] = useState(false)
+  const [triggering, setTriggering] = useState(false)
   const [notice, setNotice] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -37,6 +38,22 @@ export default function AdminPushPage() {
       setError(apiErrorMessage(err))
     } finally {
       setSending(false)
+    }
+  }
+
+  // Manually trigger the unbet-match reminder job (the one the scheduler runs every
+  // 15 min). Idempotent server-side, so re-clicking won't double-send.
+  const onTriggerReminders = async () => {
+    setNotice(null)
+    setError(null)
+    setTriggering(true)
+    try {
+      await api.post('/push/reminders')
+      setNotice('Zlecono wysłanie przypomnień o niezatypowanych meczach.')
+    } catch (err) {
+      setError(apiErrorMessage(err))
+    } finally {
+      setTriggering(false)
     }
   }
 
@@ -98,6 +115,28 @@ export default function AdminPushPage() {
           )}
         </button>
       </form>
+
+      <section className="card mt-4 space-y-3 p-4 sm:p-5">
+        <div>
+          <h2 className="font-semibold text-ink">Przypomnienia o niezatypowanych meczach</h2>
+          <p className="text-sm text-muted">
+            Ręcznie uruchom wysyłkę przypomnień — to samo zadanie, które planowo działa co 15 minut.
+            Trafią tylko do osób z niezatypowanym meczem w oknie 24h / 6h / 1h przed startem, z
+            pominięciem już wysłanych.
+          </p>
+        </div>
+        <button type="button" className="btn btn-outline" onClick={onTriggerReminders} disabled={triggering}>
+          {triggering ? (
+            <>
+              <i className="fas fa-spinner fa-spin" aria-hidden="true" /> Wysyłanie…
+            </>
+          ) : (
+            <>
+              <i className="fas fa-bell" aria-hidden="true" /> Wyślij przypomnienia teraz
+            </>
+          )}
+        </button>
+      </section>
     </>
   )
 }

--- a/spec/requests/api/v1/push/reminders_spec.rb
+++ b/spec/requests/api/v1/push/reminders_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Push::Reminders', type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:user) { create(:user) }
+
+  it 'enqueues the reminder job for an admin' do
+    expect do
+      post '/api/v1/push/reminders', headers: auth_headers(admin)
+    end.to have_enqueued_job(SendMatchRemindersJob)
+
+    expect(response).to have_http_status(:accepted)
+  end
+
+  it 'forbids non-admins' do
+    post '/api/v1/push/reminders', headers: auth_headers(user)
+    expect(response).to have_http_status(:forbidden)
+  end
+end


### PR DESCRIPTION
Add POST /api/v1/push/reminders (admin-only) that enqueues SendMatchRemindersJob — the same job the scheduler runs every 15 minutes — and a "Wyślij przypomnienia teraz" button on the admin push page. Idempotent server-side (match_reminders), so it won't double-send. Handy for testing the reminder path without waiting for the timer.