### PR TITLE
Fix: match shown as in-progress when starting >24 days away

### DIFF
--- a/frontend/src/lib/useLocalStarted.ts
+++ b/frontend/src/lib/useLocalStarted.ts
@@ -11,6 +11,9 @@ export function useLocalStarted(match: Match): boolean {
     if (started) return
     const ms = new Date(match.start).getTime() - Date.now()
     if (ms <= 0) { setStarted(true); return }
+    // setTimeout silently overflows for delays > 2^31-1 ms (~24.8 days) and fires
+    // immediately — skip the timer for far-future matches.
+    if (ms > 2_147_483_647) return
     const id = setTimeout(() => setStarted(true), ms)
     return () => clearTimeout(id)
   }, [match.start, started])


### PR DESCRIPTION
## Summary

- `useLocalStarted` schedules a `setTimeout` to flip the "started" flag at kickoff without a page refresh
- `setTimeout` silently overflows for delays > 2^31−1 ms (~24.8 days) and fires **immediately**, causing matches more than ~24 days away to show the live "Trwa" indicator right away
- Fix: skip the timer entirely when `ms > 2_147_483_647`; those matches are far enough out that a normal page refresh before kickoff is fine

## Test Plan

- [ ] Verify a match starting in 1+ month no longer shows "Trwa" on the matches list
- [ ] Verify a match starting within the next few minutes still auto-flips to live without a page refresh