### PR TITLE
Fix flag vertical alignment in match line

### DIFF
--- a/frontend/src/components/MatchLine.tsx
+++ b/frontend/src/components/MatchLine.tsx
@@ -60,15 +60,15 @@ export default function MatchLine({ match, started }: { match: Match; started?: 
         {!localStarted && <Countdown start={match.start} />}
       </span>
       <span className="flex flex-1 items-center justify-center gap-2 sm:gap-3">
-        <span className="flex-1 text-right font-semibold text-ink group-hover:text-brand">
+        <span className="flex flex-1 items-center justify-end gap-2 font-semibold text-ink group-hover:text-brand">
           {match.team_a}
-          <Flag team={match.team_a} className="ml-2 inline-block h-3.5 w-5 rounded-sm align-[-0.15em]" />
+          <Flag team={match.team_a} className="h-3.5 w-5 shrink-0 rounded-sm" />
         </span>
         <span className="shrink-0 rounded-md bg-surface px-2 py-1 text-sm font-bold tabular-nums text-ink">
           {formattedScore(match.result_a, match.result_b)}
         </span>
-        <span className="flex-1 text-left font-semibold text-ink group-hover:text-brand">
-          <Flag team={match.team_b} className="mr-2 inline-block h-3.5 w-5 rounded-sm align-[-0.15em]" />
+        <span className="flex flex-1 items-center gap-2 font-semibold text-ink group-hover:text-brand">
+          <Flag team={match.team_b} className="h-3.5 w-5 shrink-0 rounded-sm" />
           {match.team_b}
         </span>
       </span>


### PR DESCRIPTION
## Summary

- Flags in the match line were rendering slightly below the team name text due to unreliable `vertical-align` inline hacks
- Switched both team name spans from inline to `flex items-center`, so flags align via flexbox rather than baseline math
- Also replaced per-flag `ml-2`/`mr-2` margins with `gap-2` on the container

## Test Plan

- [ ] Verify flags sit vertically centred with team names on the matches list
- [ ] Check both left (team A) and right (team B) sides