### PR TITLE
Improve ranking charts: grid lines, dots, user-scoped Y-axis

### DIFF
--- a/frontend/src/components/MatchLine.tsx
+++ b/frontend/src/components/MatchLine.tsx
@@ -60,15 +60,15 @@ export default function MatchLine({ match, started }: { match: Match; started?: 
         {!localStarted && <Countdown start={match.start} />}
       </span>
       <span className="flex flex-1 items-center justify-center gap-2 sm:gap-3">
-        <span className="flex-1 text-right font-semibold text-ink group-hover:text-brand">
+        <span className="flex flex-1 items-center justify-end gap-2 font-semibold text-ink group-hover:text-brand">
           {match.team_a}
-          <Flag team={match.team_a} className="ml-2 inline-block h-3.5 w-5 rounded-sm align-[-0.15em]" />
+          <Flag team={match.team_a} className="h-3.5 w-5 shrink-0 rounded-sm" />
         </span>
         <span className="shrink-0 rounded-md bg-surface px-2 py-1 text-sm font-bold tabular-nums text-ink">
           {formattedScore(match.result_a, match.result_b)}
         </span>
-        <span className="flex-1 text-left font-semibold text-ink group-hover:text-brand">
-          <Flag team={match.team_b} className="mr-2 inline-block h-3.5 w-5 rounded-sm align-[-0.15em]" />
+        <span className="flex flex-1 items-center gap-2 font-semibold text-ink group-hover:text-brand">
+          <Flag team={match.team_b} className="h-3.5 w-5 shrink-0 rounded-sm" />
           {match.team_b}
         </span>
       </span>

--- a/frontend/src/components/RankingBumpChart.tsx
+++ b/frontend/src/components/RankingBumpChart.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
+import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer } from 'recharts'
 import { useRankingHistory } from '@/api/hooks'
 import { useAuth } from '@/auth/AuthContext'
 import { ErrorBox, Loading } from '@/components/Status'
@@ -8,7 +8,6 @@ import type { RankingHistoryMatch } from '@/api/types'
 
 const COL_PX = 20
 const MAX_X_TICKS = 12
-// Shorter chart on mobile, taller on desktop where the legend sits beside it
 const MOBILE_CHART_HEIGHT = 320
 const DESKTOP_CHART_HEIGHT_PER_USER = 14
 const DESKTOP_CHART_MIN_HEIGHT = 500
@@ -162,17 +161,25 @@ export default function RankingBumpChart({ enabled }: Props) {
   const totalUsers = series.length
   const chartWidth = Math.max(matches.length * COL_PX, 600)
   const desktopChartHeight = Math.max(DESKTOP_CHART_MIN_HEIGHT, totalUsers * DESKTOP_CHART_HEIGHT_PER_USER)
-  const yTicks = Array.from(new Set(series.flatMap((s) => s.positions))).sort((a, b) => a - b)
+
+  // Pick the smallest "nice" interval that yields ≤12 grid lines
+  const niceIntervals = [1, 2, 5, 10, 20, 25, 50]
+  const gridInterval = niceIntervals.find((i) => Math.ceil(totalUsers / i) <= 12) ?? 50
+  const yTicks = Array.from({ length: Math.floor(totalUsers / gridInterval) }, (_, i) => (i + 1) * gridInterval)
 
   const toggleHighlight = (id: number) => setHighlightedId((prev) => (prev === id ? null : id))
 
-  const chart = (height: number) => (
+  const xDomain: [number, number] = matches.length === 1 ? [0.5, 1.5] : [1, matches.length]
+  const showDots = matches.length <= 5
+
+  const chart = (
     <LineChart
       data={rows}
-      margin={{ top: 16, right: 24, bottom: 16, left: 8 }}
+      margin={{ top: 20, right: 24, bottom: 16, left: 8 }}
       onMouseLeave={() => setHoveredUserId(null)}
     >
-      <XAxis dataKey="x" type="number" domain={[1, matches.length]} ticks={xTicks(matches.length)} />
+      <CartesianGrid horizontal vertical={false} strokeDasharray="4 4" stroke="#E4E4E4" />
+      <XAxis dataKey="x" type="number" domain={xDomain} ticks={xTicks(matches.length)} />
       <YAxis reversed domain={[1, totalUsers]} ticks={yTicks} allowDecimals={false} width={32} />
       <Tooltip
         content={
@@ -193,7 +200,7 @@ export default function RankingBumpChart({ enabled }: Props) {
             dataKey={uid}
             stroke={color}
             strokeWidth={isMe || isHighlighted ? 2.5 : 1.5}
-            dot={false}
+            dot={showDots ? { r: 3, fill: color, strokeWidth: 0 } : false}
             activeDot={{ r: 4, onMouseEnter: () => setHoveredUserId(uid), onMouseLeave: () => setHoveredUserId(null) }}
             strokeOpacity={isDimmed ? 0.1 : 1}
             isAnimationActive={false}
@@ -208,24 +215,26 @@ export default function RankingBumpChart({ enabled }: Props) {
     <>
       {/* ── Mobile layout ── */}
       <div className="lg:hidden">
-        <div className="flex items-stretch">
-          <div className="flex shrink-0 items-center justify-center" style={{ width: 16 }}>
-            <span
-              className="text-[10px] font-medium text-muted"
-              style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)', whiteSpace: 'nowrap' }}
-            >
-              Pozycja
-            </span>
-          </div>
-          <div className="min-w-0 flex-1 overflow-x-auto">
-            <div style={{ minWidth: chartWidth }}>
-              <ResponsiveContainer width="100%" height={MOBILE_CHART_HEIGHT}>
-                {chart(MOBILE_CHART_HEIGHT)}
-              </ResponsiveContainer>
+        <div className="card overflow-hidden px-2 pb-2 pt-3">
+          <div className="flex items-stretch">
+            <div className="flex shrink-0 items-center justify-center" style={{ width: 16 }}>
+              <span
+                className="text-[10px] font-medium text-muted"
+                style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)', whiteSpace: 'nowrap' }}
+              >
+                Pozycja
+              </span>
+            </div>
+            <div className="min-w-0 flex-1 overflow-x-auto">
+              <div style={{ minWidth: chartWidth }}>
+                <ResponsiveContainer width="100%" height={MOBILE_CHART_HEIGHT}>
+                  {chart}
+                </ResponsiveContainer>
+              </div>
             </div>
           </div>
+          <p className="mt-1 text-center text-[10px] font-medium text-muted">Numer meczu</p>
         </div>
-        <p className="mt-1 text-center text-[10px] font-medium text-muted">Numer meczu</p>
 
         {/* Collapsible legend */}
         <div className="card mt-3 overflow-hidden">
@@ -262,7 +271,7 @@ export default function RankingBumpChart({ enabled }: Props) {
 
       {/* ── Desktop layout ── */}
       <div className="hidden lg:flex lg:items-start lg:gap-4">
-        <div className="min-w-0 flex-1">
+        <div className="card min-w-0 flex-1 overflow-hidden px-2 pb-2 pt-3">
           <div className="flex items-stretch">
             <div className="flex shrink-0 items-center justify-center" style={{ width: 20 }}>
               <span
@@ -275,7 +284,7 @@ export default function RankingBumpChart({ enabled }: Props) {
             <div className="min-w-0 flex-1 overflow-x-auto">
               <div style={{ minWidth: chartWidth }}>
                 <ResponsiveContainer width="100%" height={desktopChartHeight}>
-                  {chart(desktopChartHeight)}
+                  {chart}
                 </ResponsiveContainer>
               </div>
             </div>

--- a/frontend/src/components/UserPositionChart.tsx
+++ b/frontend/src/components/UserPositionChart.tsx
@@ -1,11 +1,28 @@
-import { LineChart, Line, XAxis, YAxis, Tooltip, ReferenceLine, ResponsiveContainer } from 'recharts'
+import { LineChart, Line, XAxis, YAxis, Tooltip, ReferenceLine, CartesianGrid, ResponsiveContainer } from 'recharts'
 import { useRankingHistory } from '@/api/hooks'
 import { formatDateLong, formattedScore } from '@/lib/format'
 import type { RankingHistoryMatch } from '@/api/types'
 
-const COL_PX = 16
 const CHART_HEIGHT = 180
 const MAX_X_TICKS = 10
+
+interface DotWithLabelProps {
+  cx?: number
+  cy?: number
+  value?: number
+}
+
+function DotWithLabel({ cx, cy, value }: DotWithLabelProps) {
+  if (cx == null || cy == null || value == null) return null
+  return (
+    <g>
+      <circle cx={cx} cy={cy} r={3} fill="var(--color-brand, #12A751)" stroke="none" />
+      <text x={cx} y={cy - 7} textAnchor="middle" fontSize={9} fontWeight={600} fill="var(--color-brand, #12A751)">
+        {value}
+      </text>
+    </g>
+  )
+}
 
 function xTicks(count: number): number[] {
   if (count <= MAX_X_TICKS) return Array.from({ length: count }, (_, i) => i + 1)
@@ -56,26 +73,31 @@ interface Props {
 
 export default function UserPositionChart({ userId }: Props) {
   const { data, isLoading } = useRankingHistory(true)
-
   if (isLoading || !data) return null
 
   const { matches, series } = data
   const userSeries = series.find((s) => s.user.id === userId)
 
-  if (!userSeries || matches.length === 0) return null
+  if (!userSeries || matches.length === 0) {
+    return (
+      <div className="card card-body text-center text-sm text-muted">
+        Historia pozycji pojawi się po zakończeniu pierwszego meczu
+      </div>
+    )
+  }
 
   const totalUsers = series.length
-  const chartWidth = Math.max(matches.length * COL_PX, 300)
-  const yTicks = Array.from(new Set(series.flatMap((s) => s.positions))).sort((a, b) => a - b)
 
   const rows = matches.map((_, i) => ({
     x: i + 1,
     position: userSeries.positions[i],
   }))
 
-  // Best and worst positions for reference lines
   const best = Math.min(...userSeries.positions)
+  const worst = Math.max(...userSeries.positions)
   const last = userSeries.positions[userSeries.positions.length - 1]
+
+  const yTicks = best === worst ? [best] : [best, worst]
 
   return (
     <div className="card overflow-hidden">
@@ -87,7 +109,6 @@ export default function UserPositionChart({ userId }: Props) {
       </div>
       <div className="px-2 pb-2 pt-1">
         <div className="flex items-stretch gap-1">
-          {/* Fixed Y-axis label */}
           <div className="flex shrink-0 items-center justify-center" style={{ width: 14 }}>
             <span
               className="text-[9px] font-medium text-muted"
@@ -96,47 +117,45 @@ export default function UserPositionChart({ userId }: Props) {
               Pozycja
             </span>
           </div>
-          <div className="min-w-0 flex-1 overflow-x-auto">
-            <div style={{ minWidth: chartWidth }}>
-              <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
-                <LineChart data={rows} margin={{ top: 8, right: 12, bottom: 8, left: 4 }}>
-                  <XAxis
-                    dataKey="x"
-                    type="number"
-                    domain={[1, matches.length]}
-                    ticks={xTicks(matches.length)}
-                    tick={{ fontSize: 10 }}
-                  />
-                  <YAxis
-                    reversed
-                    domain={[yTicks[0] ?? 1, yTicks[yTicks.length - 1] ?? totalUsers]}
-                    ticks={yTicks}
-                    allowDecimals={false}
-                    width={24}
-                    tick={{ fontSize: 10 }}
-                  />
-                  <Tooltip content={<ChartTooltip matches={matches} totalUsers={totalUsers} />} />
-                  {/* Reference line for best position */}
-                  {best < last && (
-                    <ReferenceLine
-                      y={best}
-                      stroke="var(--color-brand, #12A751)"
-                      strokeDasharray="3 3"
-                      strokeOpacity={0.4}
-                    />
-                  )}
-                  <Line
-                    dataKey="position"
+          <div className="min-w-0 flex-1">
+            <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+              <LineChart data={rows} margin={{ top: 24, right: 12, bottom: 8, left: 4 }}>
+                  <CartesianGrid horizontal vertical={false} strokeDasharray="4 4" stroke="#E4E4E4" />
+                <XAxis
+                  dataKey="x"
+                  type="number"
+                  domain={[1, matches.length]}
+                  ticks={xTicks(matches.length)}
+                  tick={{ fontSize: 10 }}
+                />
+                <YAxis
+                  reversed
+                  domain={[best, worst]}
+                  ticks={yTicks}
+                  allowDecimals={false}
+                  width={24}
+                  tick={{ fontSize: 10 }}
+                />
+                <Tooltip content={<ChartTooltip matches={matches} totalUsers={totalUsers} />} />
+                {best < last && (
+                  <ReferenceLine
+                    y={best}
                     stroke="var(--color-brand, #12A751)"
-                    strokeWidth={2}
-                    dot={false}
-                    activeDot={{ r: 4 }}
-                    isAnimationActive={false}
-                    connectNulls
+                    strokeDasharray="3 3"
+                    strokeOpacity={0.4}
                   />
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
+                )}
+                <Line
+                  dataKey="position"
+                  stroke="var(--color-brand, #12A751)"
+                  strokeWidth={2}
+                  dot={matches.length <= 5 ? (props: DotWithLabelProps) => <DotWithLabel {...props} /> : false}
+                  activeDot={{ r: 4 }}
+                  isAnimationActive={false}
+                  connectNulls
+                />
+              </LineChart>
+            </ResponsiveContainer>
           </div>
         </div>
         <p className="mt-0.5 text-center text-[10px] font-medium text-muted">Numer meczu</p>


### PR DESCRIPTION
## Summary

- **Global bump chart** (`RankingBumpChart`): wrapped in a white card, horizontal dashed grid lines at dynamically computed position intervals (targets ≤12 lines, adapts from every-1 for small groups to every-10 for 100+ users), dots shown when ≤5 matches played, edge-case fixes for single-match X-axis and position-1 label clipping
- **User profile chart** (`UserPositionChart`): Y-axis zoomed to the user's own best/worst positions instead of the full 1–N range, position numbers shown as labels above dots for ≤5 matches, same horizontal grid lines, placeholder card shown when no matches are finished yet

## Test Plan
- [ ] Visit `/ranking?view=chart` — chart appears in a white card with visible dashed horizontal grid lines
- [ ] Visit a user profile (e.g. `/users/5`) — position history chart shows zoomed Y-axis with dot labels and grid lines
- [ ] Verify grid line count scales correctly as more matches are added
- [ ] Verify placeholder text appears on a profile with 0 finished matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)