### PR TITLE
Add bet distribution donut chart on match page

### DIFF
--- a/docs/superpowers/plans/2026-06-12-bet-distribution-chart.md
+++ b/docs/superpowers/plans/2026-06-12-bet-distribution-chart.md
@@ -1,0 +1,212 @@
+# Bet Distribution Chart Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a donut chart inside the "Typy uczestników" card on the match detail page showing how many players chose each bet type.
+
+**Architecture:** A new self-contained `BetDistributionChart` component derives counts from the `participants` array already available in `MatchPage` and renders a recharts donut chart with a legend. `MatchPage` is minimally modified to render the chart between the card header and the participant list.
+
+**Tech Stack:** React, TypeScript, recharts (`PieChart`, `Pie`, `Cell`, `Tooltip`), Tailwind CSS
+
+---
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| Create | `frontend/src/components/BetDistributionChart.tsx` |
+| Modify | `frontend/src/pages/MatchPage.tsx` |
+
+---
+
+### Task 1: Create `BetDistributionChart` component
+
+**Files:**
+- Create: `frontend/src/components/BetDistributionChart.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+import { PieChart, Pie, Cell, Tooltip } from 'recharts'
+import { BET_TYPES } from '@/lib/bets'
+import type { Participant } from '@/api/types'
+
+const COLORS = ['#6366f1', '#8b5cf6', '#a78bfa', '#c4b5fd', '#ddd6fe', '#e0e7ff']
+
+interface Props {
+  participants: Participant[]
+}
+
+interface TooltipPayload {
+  name: string
+  value: number
+}
+
+interface CustomTooltipProps {
+  active?: boolean
+  payload?: { payload: TooltipPayload }[]
+}
+
+function CustomTooltip({ active, payload }: CustomTooltipProps) {
+  if (!active || !payload?.length) return null
+  const { value } = payload[0].payload
+  return (
+    <div className="card card-body py-1.5 text-xs shadow-lg">
+      {value} {value === 1 ? 'gracz' : 'graczy'}
+    </div>
+  )
+}
+
+export default function BetDistributionChart({ participants }: Props) {
+  const data = BET_TYPES.map(([result, label], i) => ({
+    label,
+    count: participants.filter((p) => p.result === result).length,
+    color: COLORS[i],
+  })).filter((d) => d.count > 0)
+
+  if (data.length === 0) return null
+
+  const total = data.reduce((sum, d) => sum + d.count, 0)
+
+  return (
+    <div className="flex items-center gap-6 px-4 py-4 sm:px-5">
+      <div className="relative shrink-0">
+        <PieChart width={120} height={120}>
+          <Pie
+            data={data}
+            dataKey="count"
+            nameKey="label"
+            cx={60}
+            cy={60}
+            innerRadius={34}
+            outerRadius={56}
+            strokeWidth={0}
+            isAnimationActive={false}
+          >
+            {data.map((entry) => (
+              <Cell key={entry.label} fill={entry.color} />
+            ))}
+          </Pie>
+          <Tooltip content={<CustomTooltip />} />
+        </PieChart>
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-lg font-bold text-ink">{total}</span>
+          <span className="text-[10px] text-muted">graczy</span>
+        </div>
+      </div>
+
+      <ul className="space-y-1 text-xs">
+        {data.map((entry) => (
+          <li key={entry.label} className="flex items-center gap-2">
+            <span
+              className="inline-block h-2.5 w-3 shrink-0 rounded-sm"
+              style={{ backgroundColor: entry.color }}
+            />
+            <span className="font-semibold text-ink">{entry.label}</span>
+            <span className="text-muted">— {entry.count} {entry.count === 1 ? 'gracz' : 'graczy'}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /Users/qarol/Work/typerek-cepe/frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/BetDistributionChart.tsx
+git commit -m "feat: add BetDistributionChart donut component"
+```
+
+---
+
+### Task 2: Integrate chart into `MatchPage`
+
+**Files:**
+- Modify: `frontend/src/pages/MatchPage.tsx`
+
+- [ ] **Step 1: Add import**
+
+At the top of `MatchPage.tsx`, after the existing component imports, add:
+
+```tsx
+import BetDistributionChart from '@/components/BetDistributionChart'
+```
+
+- [ ] **Step 2: Render chart inside the participants section**
+
+The current participants section in `MatchPage.tsx` looks like:
+
+```tsx
+{match.started && match.participants && (
+  <section className="card overflow-hidden">
+    <div className="card-header">
+      <h3 className="flex items-center gap-2">
+        <i className="fas fa-users text-brand" aria-hidden="true" /> Typy uczestników
+      </h3>
+    </div>
+    <div className="divide-y divide-line/60">
+      {match.participants.map((participant) => (
+```
+
+Replace it with:
+
+```tsx
+{match.started && match.participants && (
+  <section className="card overflow-hidden">
+    <div className="card-header">
+      <h3 className="flex items-center gap-2">
+        <i className="fas fa-users text-brand" aria-hidden="true" /> Typy uczestników
+      </h3>
+    </div>
+    <div className="border-b border-line/60">
+      <BetDistributionChart participants={match.participants} />
+    </div>
+    <div className="divide-y divide-line/60">
+      {match.participants.map((participant) => (
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+cd /Users/qarol/Work/typerek-cepe/frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Run the dev server and visually verify**
+
+Start the dev server and open a match page for a started match. Confirm:
+- Donut chart appears between the header and the participant list.
+- Center shows total player count.
+- Legend lists only bet types with ≥1 vote.
+- Hovering a slice shows "N gracz/graczy" tooltip.
+- If no participant has a bet, the chart section is hidden (the `border-b` wrapper div will be empty — adjust if needed: wrap in `{match.participants.some(p => p.result) && <div ...>}`).
+
+- [ ] **Step 5: Fix empty-chart border if needed**
+
+If the `border-b` wrapper div is visible even when the chart is hidden (because all bets are null), update the wrapper to be conditional:
+
+```tsx
+{match.participants.some((p) => p.result != null) && (
+  <div className="border-b border-line/60">
+    <BetDistributionChart participants={match.participants} />
+  </div>
+)}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/MatchPage.tsx
+git commit -m "feat: show bet distribution chart on match page"
+```

--- a/docs/superpowers/specs/2026-06-12-bet-distribution-chart-design.md
+++ b/docs/superpowers/specs/2026-06-12-bet-distribution-chart-design.md
@@ -1,0 +1,78 @@
+# Bet Distribution Donut Chart — Design Spec
+
+**Date:** 2026-06-12
+**Status:** Approved
+
+## Summary
+
+When a match has started, the "Typy uczestników" card on the match detail page shows how participants distributed their bets across the six bet types (1, X, 2, 1X, X2, 12) as a donut chart. The chart sits at the top of the card, above the per-player list.
+
+## Placement
+
+The chart renders inside the existing `match.started && match.participants` section in `MatchPage.tsx`, at the top of the `card` — between the `card-header` and the `divide-y` participant list. It is a separate `card-body`-styled block with a bottom border separating it from the list.
+
+## Component: `BetDistributionChart`
+
+**File:** `frontend/src/components/BetDistributionChart.tsx`
+
+**Props:**
+```ts
+interface Props {
+  participants: Participant[]
+}
+```
+
+**Behaviour:**
+- Counts how many participants chose each `BetType` (ignores `result: null`).
+- Filters out bet types with 0 participants — they produce no slice.
+- If the filtered list is empty (nobody has placed a bet yet), returns `null` — the component is not rendered.
+- Renders a recharts `PieChart` with `Pie` configured as a donut (`innerRadius`/`outerRadius`).
+- Each slice gets a `Cell` with a color from a fixed 6-color indigo/violet palette (consistent with the app's brand colors).
+- The center of the donut displays the total number of players who placed a bet.
+- A recharts `Tooltip` shows "N graczy" on hover (count only, no percentage).
+- A legend rendered alongside the chart lists each bet type label (1, X, 2, etc.) and its count. Only types with ≥1 vote appear in the legend.
+
+**Color palette (indexed by `BET_TYPES` order):**
+| Index | Bet | Color |
+|-------|-----|-------|
+| 0 | 1 | `#6366f1` |
+| 1 | X | `#8b5cf6` |
+| 2 | 2 | `#a78bfa` |
+| 3 | 1X | `#c4b5fd` |
+| 4 | X2 | `#ddd6fe` |
+| 5 | 12 | `#e0e7ff` |
+
+## Integration in `MatchPage`
+
+Inside the `match.started && match.participants` section, before the `divide-y` list:
+
+```tsx
+<BetDistributionChart participants={match.participants} />
+```
+
+The chart is wrapped in a `px-4 py-4 sm:px-5 border-b border-line/60` div matching the card's spacing conventions.
+
+## Data Flow
+
+All data comes from `match.participants` already fetched by `useMatch`. No new API calls or server changes are needed. The component derives counts locally:
+
+```ts
+const counts = BET_TYPES.map(([result, label]) => ({
+  result,
+  label,
+  count: participants.filter(p => p.result === result).length,
+})).filter(d => d.count > 0)
+```
+
+## Edge Cases
+
+- **No bets placed yet:** `counts` is empty → component returns `null`, chart hidden.
+- **All on one type:** Single slice fills the full donut — renders fine.
+- **One participant:** Donut shows "1" in the center, one full slice.
+
+## Out of Scope
+
+- Percentage display (count only).
+- Animation beyond recharts defaults.
+- Backend changes.
+- Finished match — chart remains visible after the match ends (data is still present).

--- a/frontend/src/components/BetDistributionChart.tsx
+++ b/frontend/src/components/BetDistributionChart.tsx
@@ -8,22 +8,21 @@ interface Props {
   participants: Participant[]
 }
 
-interface TooltipPayload {
-  name: string
-  value: number
+function pluralGraczy(n: number): string {
+  return n === 1 ? 'gracz' : 'graczy'
 }
 
 interface CustomTooltipProps {
   active?: boolean
-  payload?: { payload: TooltipPayload }[]
+  payload?: Array<{ value: number }>
 }
 
 function CustomTooltip({ active, payload }: CustomTooltipProps) {
   if (!active || !payload?.length) return null
-  const { value } = payload[0].payload
+  const count = payload[0].value ?? 0
   return (
     <div className="card card-body py-1.5 text-xs shadow-lg">
-      {value} {value === 1 ? 'gracz' : 'graczy'}
+      {count} {pluralGraczy(count)}
     </div>
   )
 }
@@ -62,7 +61,7 @@ export default function BetDistributionChart({ participants }: Props) {
         </PieChart>
         <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
           <span className="text-lg font-bold text-ink">{total}</span>
-          <span className="text-[10px] text-muted">graczy</span>
+          <span className="text-[10px] text-muted">{pluralGraczy(total)}</span>
         </div>
       </div>
 
@@ -74,7 +73,7 @@ export default function BetDistributionChart({ participants }: Props) {
               style={{ backgroundColor: entry.color }}
             />
             <span className="font-semibold text-ink">{entry.label}</span>
-            <span className="text-muted">— {entry.count} {entry.count === 1 ? 'gracz' : 'graczy'}</span>
+            <span className="text-muted">— {entry.count} {pluralGraczy(entry.count)}</span>
           </li>
         ))}
       </ul>

--- a/frontend/src/components/BetDistributionChart.tsx
+++ b/frontend/src/components/BetDistributionChart.tsx
@@ -1,0 +1,83 @@
+import { PieChart, Pie, Cell, Tooltip } from 'recharts'
+import { BET_TYPES } from '@/lib/bets'
+import type { Participant } from '@/api/types'
+
+const COLORS = ['#6366f1', '#8b5cf6', '#a78bfa', '#c4b5fd', '#ddd6fe', '#e0e7ff']
+
+interface Props {
+  participants: Participant[]
+}
+
+interface TooltipPayload {
+  name: string
+  value: number
+}
+
+interface CustomTooltipProps {
+  active?: boolean
+  payload?: { payload: TooltipPayload }[]
+}
+
+function CustomTooltip({ active, payload }: CustomTooltipProps) {
+  if (!active || !payload?.length) return null
+  const { value } = payload[0].payload
+  return (
+    <div className="card card-body py-1.5 text-xs shadow-lg">
+      {value} {value === 1 ? 'gracz' : 'graczy'}
+    </div>
+  )
+}
+
+export default function BetDistributionChart({ participants }: Props) {
+  const data = BET_TYPES.map(([result, label], i) => ({
+    label,
+    count: participants.filter((p) => p.result === result).length,
+    color: COLORS[i],
+  })).filter((d) => d.count > 0)
+
+  if (data.length === 0) return null
+
+  const total = data.reduce((sum, d) => sum + d.count, 0)
+
+  return (
+    <div className="flex items-center gap-6 px-4 py-4 sm:px-5">
+      <div className="relative shrink-0">
+        <PieChart width={120} height={120}>
+          <Pie
+            data={data}
+            dataKey="count"
+            nameKey="label"
+            cx={60}
+            cy={60}
+            innerRadius={34}
+            outerRadius={56}
+            strokeWidth={0}
+            isAnimationActive={false}
+          >
+            {data.map((entry) => (
+              <Cell key={entry.label} fill={entry.color} />
+            ))}
+          </Pie>
+          <Tooltip content={<CustomTooltip />} />
+        </PieChart>
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-lg font-bold text-ink">{total}</span>
+          <span className="text-[10px] text-muted">graczy</span>
+        </div>
+      </div>
+
+      <ul className="space-y-1 text-xs">
+        {data.map((entry) => (
+          <li key={entry.label} className="flex items-center gap-2">
+            <span
+              className="inline-block h-2.5 w-3 shrink-0 rounded-sm"
+              style={{ backgroundColor: entry.color }}
+            />
+            <span className="font-semibold text-ink">{entry.label}</span>
+            <span className="text-muted">— {entry.count} {entry.count === 1 ? 'gracz' : 'graczy'}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/src/components/BetDistributionChart.tsx
+++ b/frontend/src/components/BetDistributionChart.tsx
@@ -39,7 +39,7 @@ export default function BetDistributionChart({ participants }: Props) {
   const total = data.reduce((sum, d) => sum + d.count, 0)
 
   return (
-    <div className="flex items-center gap-6 px-4 py-4 sm:px-5">
+    <div className="flex items-center justify-center gap-6 px-4 py-4 sm:px-5">
       <div className="relative shrink-0">
         <PieChart width={120} height={120}>
           <Pie

--- a/frontend/src/components/BetDistributionChart.tsx
+++ b/frontend/src/components/BetDistributionChart.tsx
@@ -2,7 +2,7 @@ import { PieChart, Pie, Cell, Tooltip } from 'recharts'
 import { BET_TYPES } from '@/lib/bets'
 import type { Participant } from '@/api/types'
 
-const COLORS = ['#6366f1', '#8b5cf6', '#a78bfa', '#c4b5fd', '#ddd6fe', '#e0e7ff']
+const COLORS = ['#0E8C43', '#12A751', '#1dbf5f', '#4fd48a', '#86e0b0', '#bcefd4']
 
 interface Props {
   participants: Participant[]

--- a/frontend/src/components/MatchLine.tsx
+++ b/frontend/src/components/MatchLine.tsx
@@ -60,15 +60,15 @@ export default function MatchLine({ match, started }: { match: Match; started?: 
         {!localStarted && <Countdown start={match.start} />}
       </span>
       <span className="flex flex-1 items-center justify-center gap-2 sm:gap-3">
-        <span className="flex-1 text-right font-semibold text-ink group-hover:text-brand">
+        <span className="flex flex-1 items-center justify-end gap-2 font-semibold text-ink group-hover:text-brand">
           {match.team_a}
-          <Flag team={match.team_a} className="ml-2 inline-block h-3.5 w-5 rounded-sm align-[-0.15em]" />
+          <Flag team={match.team_a} className="h-3.5 w-5 shrink-0 rounded-sm" />
         </span>
         <span className="shrink-0 rounded-md bg-surface px-2 py-1 text-sm font-bold tabular-nums text-ink">
           {formattedScore(match.result_a, match.result_b)}
         </span>
-        <span className="flex-1 text-left font-semibold text-ink group-hover:text-brand">
-          <Flag team={match.team_b} className="mr-2 inline-block h-3.5 w-5 rounded-sm align-[-0.15em]" />
+        <span className="flex flex-1 items-center gap-2 font-semibold text-ink group-hover:text-brand">
+          <Flag team={match.team_b} className="h-3.5 w-5 shrink-0 rounded-sm" />
           {match.team_b}
         </span>
       </span>

--- a/frontend/src/components/RankingBumpChart.tsx
+++ b/frontend/src/components/RankingBumpChart.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
+import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer } from 'recharts'
 import { useRankingHistory } from '@/api/hooks'
 import { useAuth } from '@/auth/AuthContext'
 import { ErrorBox, Loading } from '@/components/Status'
@@ -8,7 +8,6 @@ import type { RankingHistoryMatch } from '@/api/types'
 
 const COL_PX = 20
 const MAX_X_TICKS = 12
-// Shorter chart on mobile, taller on desktop where the legend sits beside it
 const MOBILE_CHART_HEIGHT = 320
 const DESKTOP_CHART_HEIGHT_PER_USER = 14
 const DESKTOP_CHART_MIN_HEIGHT = 500
@@ -162,17 +161,25 @@ export default function RankingBumpChart({ enabled }: Props) {
   const totalUsers = series.length
   const chartWidth = Math.max(matches.length * COL_PX, 600)
   const desktopChartHeight = Math.max(DESKTOP_CHART_MIN_HEIGHT, totalUsers * DESKTOP_CHART_HEIGHT_PER_USER)
-  const yTicks = Array.from(new Set(series.flatMap((s) => s.positions))).sort((a, b) => a - b)
+
+  // Pick the smallest "nice" interval that yields ≤12 grid lines
+  const niceIntervals = [1, 2, 5, 10, 20, 25, 50]
+  const gridInterval = niceIntervals.find((i) => Math.ceil(totalUsers / i) <= 12) ?? 50
+  const yTicks = Array.from({ length: Math.floor(totalUsers / gridInterval) }, (_, i) => (i + 1) * gridInterval)
 
   const toggleHighlight = (id: number) => setHighlightedId((prev) => (prev === id ? null : id))
 
-  const chart = (height: number) => (
+  const xDomain: [number, number] = matches.length === 1 ? [0.5, 1.5] : [1, matches.length]
+  const showDots = matches.length <= 5
+
+  const chart = (
     <LineChart
       data={rows}
-      margin={{ top: 16, right: 24, bottom: 16, left: 8 }}
+      margin={{ top: 20, right: 24, bottom: 16, left: 8 }}
       onMouseLeave={() => setHoveredUserId(null)}
     >
-      <XAxis dataKey="x" type="number" domain={[1, matches.length]} ticks={xTicks(matches.length)} />
+      <CartesianGrid horizontal vertical={false} strokeDasharray="4 4" stroke="#E4E4E4" />
+      <XAxis dataKey="x" type="number" domain={xDomain} ticks={xTicks(matches.length)} />
       <YAxis reversed domain={[1, totalUsers]} ticks={yTicks} allowDecimals={false} width={32} />
       <Tooltip
         content={
@@ -193,7 +200,7 @@ export default function RankingBumpChart({ enabled }: Props) {
             dataKey={uid}
             stroke={color}
             strokeWidth={isMe || isHighlighted ? 2.5 : 1.5}
-            dot={false}
+            dot={showDots ? { r: 3, fill: color, strokeWidth: 0 } : false}
             activeDot={{ r: 4, onMouseEnter: () => setHoveredUserId(uid), onMouseLeave: () => setHoveredUserId(null) }}
             strokeOpacity={isDimmed ? 0.1 : 1}
             isAnimationActive={false}
@@ -208,24 +215,26 @@ export default function RankingBumpChart({ enabled }: Props) {
     <>
       {/* ── Mobile layout ── */}
       <div className="lg:hidden">
-        <div className="flex items-stretch">
-          <div className="flex shrink-0 items-center justify-center" style={{ width: 16 }}>
-            <span
-              className="text-[10px] font-medium text-muted"
-              style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)', whiteSpace: 'nowrap' }}
-            >
-              Pozycja
-            </span>
-          </div>
-          <div className="min-w-0 flex-1 overflow-x-auto">
-            <div style={{ minWidth: chartWidth }}>
-              <ResponsiveContainer width="100%" height={MOBILE_CHART_HEIGHT}>
-                {chart(MOBILE_CHART_HEIGHT)}
-              </ResponsiveContainer>
+        <div className="card overflow-hidden px-2 pb-2 pt-3">
+          <div className="flex items-stretch">
+            <div className="flex shrink-0 items-center justify-center" style={{ width: 16 }}>
+              <span
+                className="text-[10px] font-medium text-muted"
+                style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)', whiteSpace: 'nowrap' }}
+              >
+                Pozycja
+              </span>
+            </div>
+            <div className="min-w-0 flex-1 overflow-x-auto">
+              <div style={{ minWidth: chartWidth }}>
+                <ResponsiveContainer width="100%" height={MOBILE_CHART_HEIGHT}>
+                  {chart}
+                </ResponsiveContainer>
+              </div>
             </div>
           </div>
+          <p className="mt-1 text-center text-[10px] font-medium text-muted">Numer meczu</p>
         </div>
-        <p className="mt-1 text-center text-[10px] font-medium text-muted">Numer meczu</p>
 
         {/* Collapsible legend */}
         <div className="card mt-3 overflow-hidden">
@@ -262,7 +271,7 @@ export default function RankingBumpChart({ enabled }: Props) {
 
       {/* ── Desktop layout ── */}
       <div className="hidden lg:flex lg:items-start lg:gap-4">
-        <div className="min-w-0 flex-1">
+        <div className="card min-w-0 flex-1 overflow-hidden px-2 pb-2 pt-3">
           <div className="flex items-stretch">
             <div className="flex shrink-0 items-center justify-center" style={{ width: 20 }}>
               <span
@@ -275,7 +284,7 @@ export default function RankingBumpChart({ enabled }: Props) {
             <div className="min-w-0 flex-1 overflow-x-auto">
               <div style={{ minWidth: chartWidth }}>
                 <ResponsiveContainer width="100%" height={desktopChartHeight}>
-                  {chart(desktopChartHeight)}
+                  {chart}
                 </ResponsiveContainer>
               </div>
             </div>

--- a/frontend/src/components/UserPositionChart.tsx
+++ b/frontend/src/components/UserPositionChart.tsx
@@ -1,11 +1,28 @@
-import { LineChart, Line, XAxis, YAxis, Tooltip, ReferenceLine, ResponsiveContainer } from 'recharts'
+import { LineChart, Line, XAxis, YAxis, Tooltip, ReferenceLine, CartesianGrid, ResponsiveContainer } from 'recharts'
 import { useRankingHistory } from '@/api/hooks'
 import { formatDateLong, formattedScore } from '@/lib/format'
 import type { RankingHistoryMatch } from '@/api/types'
 
-const COL_PX = 16
 const CHART_HEIGHT = 180
 const MAX_X_TICKS = 10
+
+interface DotWithLabelProps {
+  cx?: number
+  cy?: number
+  value?: number
+}
+
+function DotWithLabel({ cx, cy, value }: DotWithLabelProps) {
+  if (cx == null || cy == null || value == null) return null
+  return (
+    <g>
+      <circle cx={cx} cy={cy} r={3} fill="var(--color-brand, #12A751)" stroke="none" />
+      <text x={cx} y={cy - 7} textAnchor="middle" fontSize={9} fontWeight={600} fill="var(--color-brand, #12A751)">
+        {value}
+      </text>
+    </g>
+  )
+}
 
 function xTicks(count: number): number[] {
   if (count <= MAX_X_TICKS) return Array.from({ length: count }, (_, i) => i + 1)
@@ -56,26 +73,31 @@ interface Props {
 
 export default function UserPositionChart({ userId }: Props) {
   const { data, isLoading } = useRankingHistory(true)
-
   if (isLoading || !data) return null
 
   const { matches, series } = data
   const userSeries = series.find((s) => s.user.id === userId)
 
-  if (!userSeries || matches.length === 0) return null
+  if (!userSeries || matches.length === 0) {
+    return (
+      <div className="card card-body text-center text-sm text-muted">
+        Historia pozycji pojawi się po zakończeniu pierwszego meczu
+      </div>
+    )
+  }
 
   const totalUsers = series.length
-  const chartWidth = Math.max(matches.length * COL_PX, 300)
-  const yTicks = Array.from(new Set(series.flatMap((s) => s.positions))).sort((a, b) => a - b)
 
   const rows = matches.map((_, i) => ({
     x: i + 1,
     position: userSeries.positions[i],
   }))
 
-  // Best and worst positions for reference lines
   const best = Math.min(...userSeries.positions)
+  const worst = Math.max(...userSeries.positions)
   const last = userSeries.positions[userSeries.positions.length - 1]
+
+  const yTicks = best === worst ? [best] : [best, worst]
 
   return (
     <div className="card overflow-hidden">
@@ -87,7 +109,6 @@ export default function UserPositionChart({ userId }: Props) {
       </div>
       <div className="px-2 pb-2 pt-1">
         <div className="flex items-stretch gap-1">
-          {/* Fixed Y-axis label */}
           <div className="flex shrink-0 items-center justify-center" style={{ width: 14 }}>
             <span
               className="text-[9px] font-medium text-muted"
@@ -96,47 +117,45 @@ export default function UserPositionChart({ userId }: Props) {
               Pozycja
             </span>
           </div>
-          <div className="min-w-0 flex-1 overflow-x-auto">
-            <div style={{ minWidth: chartWidth }}>
-              <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
-                <LineChart data={rows} margin={{ top: 8, right: 12, bottom: 8, left: 4 }}>
-                  <XAxis
-                    dataKey="x"
-                    type="number"
-                    domain={[1, matches.length]}
-                    ticks={xTicks(matches.length)}
-                    tick={{ fontSize: 10 }}
-                  />
-                  <YAxis
-                    reversed
-                    domain={[yTicks[0] ?? 1, yTicks[yTicks.length - 1] ?? totalUsers]}
-                    ticks={yTicks}
-                    allowDecimals={false}
-                    width={24}
-                    tick={{ fontSize: 10 }}
-                  />
-                  <Tooltip content={<ChartTooltip matches={matches} totalUsers={totalUsers} />} />
-                  {/* Reference line for best position */}
-                  {best < last && (
-                    <ReferenceLine
-                      y={best}
-                      stroke="var(--color-brand, #12A751)"
-                      strokeDasharray="3 3"
-                      strokeOpacity={0.4}
-                    />
-                  )}
-                  <Line
-                    dataKey="position"
+          <div className="min-w-0 flex-1">
+            <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+              <LineChart data={rows} margin={{ top: 24, right: 12, bottom: 8, left: 4 }}>
+                  <CartesianGrid horizontal vertical={false} strokeDasharray="4 4" stroke="#E4E4E4" />
+                <XAxis
+                  dataKey="x"
+                  type="number"
+                  domain={[1, matches.length]}
+                  ticks={xTicks(matches.length)}
+                  tick={{ fontSize: 10 }}
+                />
+                <YAxis
+                  reversed
+                  domain={[best, worst]}
+                  ticks={yTicks}
+                  allowDecimals={false}
+                  width={24}
+                  tick={{ fontSize: 10 }}
+                />
+                <Tooltip content={<ChartTooltip matches={matches} totalUsers={totalUsers} />} />
+                {best < last && (
+                  <ReferenceLine
+                    y={best}
                     stroke="var(--color-brand, #12A751)"
-                    strokeWidth={2}
-                    dot={false}
-                    activeDot={{ r: 4 }}
-                    isAnimationActive={false}
-                    connectNulls
+                    strokeDasharray="3 3"
+                    strokeOpacity={0.4}
                   />
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
+                )}
+                <Line
+                  dataKey="position"
+                  stroke="var(--color-brand, #12A751)"
+                  strokeWidth={2}
+                  dot={matches.length <= 5 ? (props: DotWithLabelProps) => <DotWithLabel {...props} /> : false}
+                  activeDot={{ r: 4 }}
+                  isAnimationActive={false}
+                  connectNulls
+                />
+              </LineChart>
+            </ResponsiveContainer>
           </div>
         </div>
         <p className="mt-0.5 text-center text-[10px] font-medium text-muted">Numer meczu</p>

--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -5,6 +5,7 @@ import { ErrorBox, Loading } from '@/components/Status'
 import Flag from '@/components/Flag'
 import BetGrid from '@/components/BetGrid'
 import LockToggle from '@/components/LockToggle'
+import BetDistributionChart from '@/components/BetDistributionChart'
 import { BET_TYPES, betPillClass, winningBets } from '@/lib/bets'
 import { formatShort, formattedOdds, formattedScore } from '@/lib/format'
 import { useDocumentTitle } from '@/lib/useDocumentTitle'
@@ -89,6 +90,11 @@ export default function MatchPage() {
               <i className="fas fa-users text-brand" aria-hidden="true" /> Typy uczestników
             </h3>
           </div>
+          {match.participants.some((p) => p.result != null) && (
+            <div className="border-b border-line/60">
+              <BetDistributionChart participants={match.participants} />
+            </div>
+          )}
           <div className="divide-y divide-line/60">
             {match.participants.map((participant) => (
               <div


### PR DESCRIPTION
## Summary

- Adds a `BetDistributionChart` component — a recharts donut chart showing how participants' bets are distributed across the six bet types (1, X, 2, 1X, X2, 12)
- Chart appears inside the "Typy uczestników" card, between the header and the per-player list, centered, only when at least one participant has placed a bet
- Colors use the page's brand green palette; center of the donut shows total player count; tooltip and legend show per-type counts with correct Polish pluralization

## Test Plan

- [ ] Open a match page for a started match — donut chart appears centered above the participant list
- [ ] Hover a slice — tooltip shows "N gracz/graczy" (check singular "1 gracz" is correct)
- [ ] Bet types with 0 votes are absent from chart and legend
- [ ] If no participant has placed a bet, the chart section is hidden entirely