### PR TITLE
Add settings to hide odds and double-chance bets

### DIFF
--- a/app/controllers/api/v1/profile_controller.rb
+++ b/app/controllers/api/v1/profile_controller.rb
@@ -32,7 +32,8 @@ module Api
       # into the existing settings bag, so a partial update leaves the rest intact.
       def settings_params
         params.require(:settings).permit(
-          :drzewko_mode, :bet_lock, :push_enabled, :push_results, :push_reminders
+          :drzewko_mode, :bet_lock, :hide_odds, :hide_double_chance,
+          :push_enabled, :push_results, :push_reminders
         ).to_h.transform_values do |value|
           ActiveModel::Type::Boolean.new.cast(value)
         end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,8 @@ class User < ApplicationRecord
   SETTINGS_DEFAULTS = {
     'drzewko_mode' => false,
     'bet_lock' => false,
+    'hide_odds' => false,
+    'hide_double_chance' => false,
     'push_enabled' => false,
     'push_results' => true,
     'push_reminders' => true
@@ -17,7 +19,7 @@ class User < ApplicationRecord
   # Settings we surface a "Włączone przez N osób" count for on the settings screen.
   # The push sub-toggles are excluded: they default on, so a raw `= 'true'` count
   # would be meaningless for them.
-  COUNTED_SETTINGS = %w[drzewko_mode bet_lock push_enabled].freeze
+  COUNTED_SETTINGS = %w[drzewko_mode bet_lock hide_odds hide_double_chance push_enabled].freeze
 
   has_secure_password validations: false
 
@@ -79,6 +81,18 @@ class User < ApplicationRecord
 
   def bet_lock?
     settings_with_defaults['bet_lock'] == true
+  end
+
+  # Hide the kursy (odds) printed under each 1 / X / 2 pill, so they don't
+  # influence the pick. Purely cosmetic; the odds still drive scoring.
+  def hide_odds?
+    settings_with_defaults['hide_odds'] == true
+  end
+
+  # Hide the double-chance options (1X, X2, 12) in the betting grid, leaving only
+  # 1 / X / 2. Purely a display preference; the options remain valid bets.
+  def hide_double_chance?
+    settings_with_defaults['hide_double_chance'] == true
   end
 
   def push_enabled?

--- a/app/serializers/api/v1/current_user_serializer.rb
+++ b/app/serializers/api/v1/current_user_serializer.rb
@@ -17,6 +17,8 @@ module Api
           settings: {
             drzewko_mode: user.drzewko_mode?,
             bet_lock: user.bet_lock?,
+            hide_odds: user.hide_odds?,
+            hide_double_chance: user.hide_double_chance?,
             push_enabled: user.push_enabled?,
             push_results: user.push_results?,
             push_reminders: user.push_reminders?

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -22,6 +22,10 @@ export interface Standing {
 export interface UserSettings {
   drzewko_mode: boolean
   bet_lock: boolean
+  // Hide the kursy (odds) under each 1 / X / 2 pill in the match views.
+  hide_odds: boolean
+  // Hide the double-chance options (1X, X2, 12) in the match views.
+  hide_double_chance: boolean
   // Opt-in master switch for Web Push notifications.
   push_enabled: boolean
   // Which kinds of push the user wants (only relevant when push_enabled). Default on.

--- a/frontend/src/components/BetGrid.tsx
+++ b/frontend/src/components/BetGrid.tsx
@@ -1,4 +1,4 @@
-import { BET_TYPES, betPillClass, winningBets } from '@/lib/bets'
+import { betPillClass, visibleBetTypes, winningBets } from '@/lib/bets'
 import { formattedOdds } from '@/lib/format'
 import { useSettings } from '@/lib/settings'
 import type { BetType, Match } from '@/api/types'
@@ -19,16 +19,21 @@ interface Props {
 // marks the viewer's own pick as a hit or a miss. A bet the viewer locked
 // (my_locked) is read-only too, until they unlock it via LockToggle.
 export default function BetGrid({ match, myAnswer, onBet, pending, started }: Props) {
-  const { betLock } = useSettings()
+  const { betLock, hideOdds, hideDoubleChance } = useSettings()
   const hasStarted = started ?? match.started
   // The lock only restricts editing when the viewer has the feature enabled.
   const locked = betLock && match.my_locked
   const interactive = Boolean(onBet) && !hasStarted && !locked
   const scored = match.finished ? new Set(winningBets(match.result_a, match.result_b)) : null
+  // Both "hide" preferences are about not being swayed while you can still bet, so
+  // they switch off once the match is finished — then you see the full picture
+  // (every option and its odds, with your pick marked a hit or a miss).
+  const showOdds = !hideOdds || match.finished
+  const types = visibleBetTypes(hideDoubleChance && !match.finished)
 
   return (
-    <div className="bet-grid">
-      {BET_TYPES.map(([result, label]) => {
+    <div className={`bet-grid${types.length === 3 ? ' grid-cols-3' : ''}`}>
+      {types.map(([result, label]) => {
         const active = myAnswer === result
         const isScored = scored?.has(result) ?? false
         const odds = formattedOdds(match.odds[result])
@@ -38,13 +43,13 @@ export default function BetGrid({ match, myAnswer, onBet, pending, started }: Pr
             type="button"
             disabled={!interactive || pending}
             onClick={() => onBet?.(result)}
-            aria-label={`Typ ${label}, kurs ${odds}${
+            aria-label={`Typ ${label}${showOdds ? `, kurs ${odds}` : ''}${
               active ? `, wybrany${match.finished ? (isScored ? ', trafiony' : ', nietrafiony') : ''}` : ''
             }`}
             className={betPillClass({ active, scored: isScored, finished: match.finished, interactive })}
           >
             <span className="bet-key">{label}</span>
-            <span className="bet-odds">{odds}</span>
+            {showOdds && <span className="bet-odds">{odds}</span>}
           </button>
         )
       })}

--- a/frontend/src/lib/bets.ts
+++ b/frontend/src/lib/bets.ts
@@ -10,6 +10,17 @@ export const BET_TYPES: ReadonlyArray<readonly [BetType, string]> = [
   ['not_tie', '12'],
 ]
 
+// The "double chance" bets (1X, X2, 12) — they each cover two of the three
+// outcomes. A user setting can hide them so only the plain 1 / X / 2 remain.
+export const DOUBLE_CHANCE_BETS: ReadonlySet<BetType> = new Set(['win_tie_a', 'win_tie_b', 'not_tie'])
+
+// The bet options to render, narrowed to 1 / X / 2 when the viewer opted to hide
+// the double-chance options. Used for both the pills and their legend so the two
+// stay column-aligned.
+export function visibleBetTypes(hideDoubleChance: boolean): ReadonlyArray<readonly [BetType, string]> {
+  return hideDoubleChance ? BET_TYPES.filter(([type]) => !DOUBLE_CHANCE_BETS.has(type)) : BET_TYPES
+}
+
 // Human-readable meaning of each symbol, shown as the aligned legend above the
 // pills (mirrors the column headers in Ania's typerek).
 export const BET_LEGEND: Record<BetType, string> = {

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -14,6 +14,12 @@ interface Settings {
   // Show the padlock that locks a bet against accidental changes. Opt-in: not
   // everyone wants the extra control, so it is off by default.
   betLock: boolean
+  // Hide the kursy (odds) under each 1 / X / 2 pill so they don't sway the pick.
+  // Opt-in, off by default.
+  hideOdds: boolean
+  // Hide the double-chance options (1X, X2, 12), leaving only 1 / X / 2.
+  // Opt-in, off by default. Like hideOdds, it lifts on finished matches.
+  hideDoubleChance: boolean
   // Opt-in master switch for Web Push notifications. The browser subscription side
   // effects live in usePushSubscription; this only mirrors the persisted flag.
   pushEnabled: boolean
@@ -25,6 +31,8 @@ interface Settings {
 const DEFAULTS: Settings = {
   drzewkoMode: false,
   betLock: false,
+  hideOdds: false,
+  hideDoubleChance: false,
   pushEnabled: false,
   pushResults: true,
   pushReminders: true,
@@ -35,6 +43,8 @@ function fromServer(settings: UserSettings | undefined): Settings {
   return {
     drzewkoMode: settings?.drzewko_mode ?? DEFAULTS.drzewkoMode,
     betLock: settings?.bet_lock ?? DEFAULTS.betLock,
+    hideOdds: settings?.hide_odds ?? DEFAULTS.hideOdds,
+    hideDoubleChance: settings?.hide_double_chance ?? DEFAULTS.hideDoubleChance,
     pushEnabled: settings?.push_enabled ?? DEFAULTS.pushEnabled,
     pushResults: settings?.push_results ?? DEFAULTS.pushResults,
     pushReminders: settings?.push_reminders ?? DEFAULTS.pushReminders,
@@ -46,6 +56,8 @@ interface SettingsState extends Settings {
   // so callers can reconcile any optimistic UI they showed in the meantime.
   setDrzewkoMode: (value: boolean) => Promise<void>
   setBetLock: (value: boolean) => Promise<void>
+  setHideOdds: (value: boolean) => Promise<void>
+  setHideDoubleChance: (value: boolean) => Promise<void>
   setPushEnabled: (value: boolean) => Promise<void>
   setPushResults: (value: boolean) => Promise<void>
   setPushReminders: (value: boolean) => Promise<void>
@@ -77,6 +89,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     ...settings,
     setDrzewkoMode: (drzewkoMode) => persist({ drzewkoMode }, { drzewko_mode: drzewkoMode }),
     setBetLock: (betLock) => persist({ betLock }, { bet_lock: betLock }),
+    setHideOdds: (hideOdds) => persist({ hideOdds }, { hide_odds: hideOdds }),
+    setHideDoubleChance: (hideDoubleChance) =>
+      persist({ hideDoubleChance }, { hide_double_chance: hideDoubleChance }),
     setPushEnabled: (pushEnabled) => persist({ pushEnabled }, { push_enabled: pushEnabled }),
     setPushResults: (pushResults) => persist({ pushResults }, { push_results: pushResults }),
     setPushReminders: (pushReminders) => persist({ pushReminders }, { push_reminders: pushReminders }),

--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -9,11 +9,13 @@ import BetDistributionChart from '@/components/BetDistributionChart'
 import { BET_TYPES, betPillClass, winningBets } from '@/lib/bets'
 import { formatShort, formattedOdds, formattedScore } from '@/lib/format'
 import { useDocumentTitle } from '@/lib/useDocumentTitle'
+import { useSettings } from '@/lib/settings'
 
 // Mirrors matches/show.html.erb.
 export default function MatchPage() {
   const { id = '' } = useParams()
   const { isAdmin } = useAuth()
+  const { hideOdds } = useSettings()
   const { data: match, isLoading, isError } = useMatch(id)
   const placeBet = usePlaceBet()
 
@@ -40,15 +42,15 @@ export default function MatchPage() {
           </div>
         )}
         <div className="flex items-center justify-center gap-2 sm:gap-3">
-          <div className="flex-1 text-right text-lg font-bold text-ink">
+          <div className="flex flex-1 items-center justify-end gap-4 text-right text-lg font-bold text-ink">
             {match.team_a}
-            <Flag team={match.team_a} className="ml-4 inline-block h-5 w-7 rounded-sm align-[-0.2em]" />
+            <Flag team={match.team_a} className="h-5 w-7 shrink-0 rounded-sm" />
           </div>
           <div className="shrink-0 rounded-lg bg-surface px-4 py-2 text-2xl font-bold tabular-nums text-ink">
             {formattedScore(match.result_a, match.result_b)}
           </div>
-          <div className="flex-1 text-left text-lg font-bold text-ink">
-            <Flag team={match.team_b} className="mr-4 inline-block h-5 w-7 rounded-sm align-[-0.2em]" />
+          <div className="flex flex-1 items-center gap-4 text-left text-lg font-bold text-ink">
+            <Flag team={match.team_b} className="h-5 w-7 shrink-0 rounded-sm" />
             {match.team_b}
           </div>
         </div>
@@ -124,7 +126,9 @@ export default function MatchPage() {
                           })}
                         >
                           <span className="bet-key">{label}</span>
-                          <span className="bet-odds">{formattedOdds(match.odds[result])}</span>
+                          {(!hideOdds || match.finished) && (
+                            <span className="bet-odds">{formattedOdds(match.odds[result])}</span>
+                          )}
                         </div>
                       )
                     })}

--- a/frontend/src/pages/MatchesPage.tsx
+++ b/frontend/src/pages/MatchesPage.tsx
@@ -1,7 +1,7 @@
 import { useSearchParams } from 'react-router-dom'
 import { useMatches, usePlaceBet } from '@/api/hooks'
 import { formatDateLong, groupByDay, relativeDay } from '@/lib/format'
-import { BET_TYPES, BET_LEGEND } from '@/lib/bets'
+import { BET_LEGEND, visibleBetTypes } from '@/lib/bets'
 import MatchLine from '@/components/MatchLine'
 import { useLocalStarted } from '@/lib/useLocalStarted'
 import BetGrid from '@/components/BetGrid'
@@ -52,11 +52,17 @@ function MatchRow({ match }: { match: Match }) {
 }
 
 function MatchSection({ matches }: { matches: Match[] }) {
-  const { betLock } = useSettings()
+  const { betLock, hideDoubleChance } = useSettings()
 
   if (matches.length === 0) {
     return <div className="card card-body text-center text-muted">Brak meczów</div>
   }
+
+  // A tab holds only future or only finished matches, so the whole section is
+  // homogeneous: hide the double-chance columns only when these rows are still
+  // open, keeping the legend aligned with the pills below it.
+  const hideDc = hideDoubleChance && matches.some((match) => !match.finished)
+  const legendTypes = visibleBetTypes(hideDc)
 
   return (
     <div className="space-y-4">
@@ -71,8 +77,8 @@ function MatchSection({ matches }: { matches: Match[] }) {
                 the bet pills below (hidden on mobile, where the row stacks). The
                 trailing spacer mirrors each row's padlock slot so the columns line up. */}
             <div className="hidden items-center gap-2 sm:flex">
-              <div className="grid w-[340px] grid-cols-6 gap-1.5 sm:gap-2">
-                {BET_TYPES.map(([result]) => (
+              <div className={`grid w-[340px] gap-1.5 sm:gap-2 ${hideDc ? 'grid-cols-3' : 'grid-cols-6'}`}>
+                {legendTypes.map(([result]) => (
                   <div key={result} className="text-center text-[10px] leading-tight text-muted">
                     {BET_LEGEND[result]}
                   </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -7,7 +7,13 @@ import Alert from '@/components/Alert'
 import type { PushDevice } from '@/api/types'
 
 // Number of users with each setting switched on, keyed by the server setting name.
-type SettingsStats = { drzewko_mode: number; bet_lock: number; push_enabled: number }
+type SettingsStats = {
+  drzewko_mode: number
+  bet_lock: number
+  hide_odds: number
+  hide_double_chance: number
+  push_enabled: number
+}
 
 // Polish accusative of "osoba" for the "Włączone przez N osób" hint:
 // 1 → osobę, 2–4 (but not 12–14) → osoby, otherwise → osób.
@@ -60,6 +66,10 @@ export default function SettingsPage() {
     setDrzewkoMode,
     betLock,
     setBetLock,
+    hideOdds,
+    setHideOdds,
+    hideDoubleChance,
+    setHideDoubleChance,
     pushResults,
     setPushResults,
     pushReminders,
@@ -282,6 +292,40 @@ export default function SettingsPage() {
               przypadkiem go nie zmienić.
             </span>
             <UsageHint count={stats?.bet_lock} />
+          </span>
+        </label>
+
+        <label className="flex cursor-pointer items-start gap-3 px-4 py-4 sm:px-5">
+          <input
+            type="checkbox"
+            className="mt-0.5 h-5 w-5 shrink-0 accent-brand"
+            checked={hideOdds}
+            onChange={(event) => toggle('hide_odds', setHideOdds, event.target.checked)}
+          />
+          <span className="leading-snug">
+            <span className="block font-semibold text-ink">Ukryj kursy</span>
+            <span className="block text-muted">
+              Chowa kursy przy typach (1, X, 2, …) na liście meczów i na stronie meczu, żeby się
+              nimi nie sugerować przy obstawianiu. Po zakończeniu meczu kursy znów są widoczne.
+            </span>
+            <UsageHint count={stats?.hide_odds} />
+          </span>
+        </label>
+
+        <label className="flex cursor-pointer items-start gap-3 px-4 py-4 sm:px-5">
+          <input
+            type="checkbox"
+            className="mt-0.5 h-5 w-5 shrink-0 accent-brand"
+            checked={hideDoubleChance}
+            onChange={(event) => toggle('hide_double_chance', setHideDoubleChance, event.target.checked)}
+          />
+          <span className="leading-snug">
+            <span className="block font-semibold text-ink">Ukryj typy podwójne</span>
+            <span className="block text-muted">
+              Chowa typy podwójne (1X, X2, 12) na liście meczów i na stronie meczu — zostają tylko
+              1, X i 2. Po zakończeniu meczu znów są widoczne.
+            </span>
+            <UsageHint count={stats?.hide_double_chance} />
           </span>
         </label>
       </section>

--- a/spec/requests/api/v1/profile_spec.rb
+++ b/spec/requests/api/v1/profile_spec.rb
@@ -18,8 +18,9 @@ RSpec.describe 'API V1 Profile', type: :request do
       get '/api/v1/me', headers: auth_headers(user)
 
       expect(json['settings']).to eq(
-        'drzewko_mode' => false, 'bet_lock' => false,
-        'push_enabled' => false, 'push_results' => true, 'push_reminders' => true
+        'drzewko_mode' => false, 'bet_lock' => false, 'hide_odds' => false,
+        'hide_double_chance' => false, 'push_enabled' => false,
+        'push_results' => true, 'push_reminders' => true
       )
     end
 
@@ -40,7 +41,10 @@ RSpec.describe 'API V1 Profile', type: :request do
       get '/api/v1/me/settings/stats', headers: auth_headers(user)
 
       expect(response).to have_http_status(:ok)
-      expect(json).to eq('drzewko_mode' => 2, 'bet_lock' => 1, 'push_enabled' => 0)
+      expect(json).to eq(
+        'drzewko_mode' => 2, 'bet_lock' => 1, 'hide_odds' => 0,
+        'hide_double_chance' => 0, 'push_enabled' => 0
+      )
     end
 
     it 'returns 401 without a token' do
@@ -58,8 +62,9 @@ RSpec.describe 'API V1 Profile', type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(json['settings']).to eq(
-        'drzewko_mode' => false, 'bet_lock' => true,
-        'push_enabled' => false, 'push_results' => true, 'push_reminders' => true
+        'drzewko_mode' => false, 'bet_lock' => true, 'hide_odds' => false,
+        'hide_double_chance' => false, 'push_enabled' => false,
+        'push_results' => true, 'push_reminders' => true
       )
       expect(user.reload.bet_lock?).to be(true)
     end


### PR DESCRIPTION
Two independent, opt-in display preferences (off by default), wired through the same per-user settings path as the existing toggles:

- "Ukryj kursy" hides the kursy under each 1/X/2 pill.
- "Ukryj typy podwójne" hides 1X/X2/12, leaving only 1/X/2 (grid drops to 3 columns; the match-list legend narrows to match).

Both apply in the match list and single match views, and both lift on finished matches — once betting is closed you see every option and its odds, with your pick still marked a hit or a miss.

Also align the team flags in the single-match header with the same flex/items-center approach used for the match line in 5b7e88d, replacing the unreliable inline vertical-align hack.