### PR TITLE
Make ranking readable: configurable prize zone, movement, gaps

### DIFF
--- a/app/serializers/api/v1/current_user_serializer.rb
+++ b/app/serializers/api/v1/current_user_serializer.rb
@@ -13,6 +13,10 @@ module Api
           username: user.username,
           admin: user.admin?,
           standing: standing && { rank: standing[:position], points: standing[:points] },
+          # How many top places are rewarded this season (the "prize zone"). A pure
+          # app-level constant, surfaced here — like discord_url — so the SPA can read
+          # it once at sign-in and highlight the zone in the ranking and the chart.
+          rewarded_positions: Typerek::Ranking::REWARDED_POSITIONS,
           discord_url: ENV['TYPEREK_DISCORD_URL'].presence,
           settings: {
             drzewko_mode: user.drzewko_mode?,

--- a/app/serializers/api/v1/ranking_entry_serializer.rb
+++ b/app/serializers/api/v1/ranking_entry_serializer.rb
@@ -11,6 +11,7 @@ module Api
       def self.call(entry)
         {
           position: entry.position,
+          previous_position: entry.previous_position,
           user: { id: entry.user.id, username: entry.user.username },
           points: entry.points,
           accuracy: entry.accuracy

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -46,6 +46,9 @@ export interface CurrentUser {
   username: string
   admin: boolean
   standing: Standing | null
+  // How many top places are rewarded this season — the "prize zone" the ranking
+  // and the bump chart highlight. An app-level constant, same for everyone.
+  rewarded_positions: number
   // Community Discord invite, served only to signed-in users; null when unset.
   discord_url: string | null
   settings: UserSettings
@@ -97,6 +100,9 @@ export interface Answer {
 
 export interface RankingEntry {
   position: number
+  // Position before the most recent finished match, for the movement arrow; null
+  // until there is a prior ranking to compare against.
+  previous_position: number | null
   user: { id: number; username: string }
   points: number
   accuracy: number

--- a/frontend/src/components/RankingBumpChart.tsx
+++ b/frontend/src/components/RankingBumpChart.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer } from 'recharts'
+import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ReferenceLine, ResponsiveContainer } from 'recharts'
 import { useRankingHistory } from '@/api/hooks'
 import { useAuth } from '@/auth/AuthContext'
 import { ErrorBox, Loading } from '@/components/Status'
@@ -159,6 +159,7 @@ export default function RankingBumpChart({ enabled }: Props) {
   })
 
   const totalUsers = series.length
+  const rewarded = me?.rewarded_positions ?? 0
   const chartWidth = Math.max(matches.length * COL_PX, 600)
   const desktopChartHeight = Math.max(DESKTOP_CHART_MIN_HEIGHT, totalUsers * DESKTOP_CHART_HEIGHT_PER_USER)
 
@@ -181,6 +182,18 @@ export default function RankingBumpChart({ enabled }: Props) {
       <CartesianGrid horizontal vertical={false} strokeDasharray="4 4" stroke="#E4E4E4" />
       <XAxis dataKey="x" type="number" domain={xDomain} ticks={xTicks(matches.length)} />
       <YAxis reversed domain={[1, totalUsers]} ticks={yTicks} allowDecimals={false} width={32} />
+      {/* Cutoff between the prize zone (positions 1..N) and the rest. Drawn at the
+          half-step so it sits in the gap between the Nth and (N+1)th place lines. */}
+      {rewarded > 0 && rewarded < totalUsers && (
+        <ReferenceLine
+          y={rewarded + 0.5}
+          stroke="#f59e0b"
+          strokeDasharray="5 4"
+          strokeWidth={1.5}
+          ifOverflow="extendDomain"
+          label={{ value: 'strefa nagród', position: 'insideTopLeft', fill: '#b45309', fontSize: 10 }}
+        />
+      )}
       <Tooltip
         content={
           <CustomTooltip matches={matches} userMap={userMap} meId={me?.id} hoveredUserId={hoveredUserId} />

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { Fragment, useRef } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { useRanking } from '@/api/hooks'
 import { useAuth } from '@/auth/AuthContext'
@@ -7,11 +7,51 @@ import RankingBumpChart from '@/components/RankingBumpChart'
 import { pointsDisplay } from '@/lib/format'
 import { useSettings } from '@/lib/settings'
 import { useDocumentTitle } from '@/lib/useDocumentTitle'
+import type { RankingEntry } from '@/api/types'
 
-const BADGES: Record<number, string> = {
-  1: 'bg-yellow-400 text-white',
-  2: 'bg-gray-300 text-ink',
-  3: 'bg-amber-600 text-white',
+// Colour of the round position badge. Gold / silver / bronze for the podium, a
+// softer amber for the rest of the prize zone (positions 4..N), plain otherwise.
+function positionBadgeClass(position: number, rewarded: number): string {
+  if (position === 1) return 'bg-yellow-400 text-white'
+  if (position === 2) return 'bg-gray-300 text-ink'
+  if (position === 3) return 'bg-amber-600 text-white'
+  if (position <= rewarded) return 'bg-amber-100 text-amber-700 ring-1 ring-amber-300'
+  return 'bg-surface text-muted'
+}
+
+// Polish noun after a count: 1 miejsce, 2–4 miejsca, otherwise miejsc.
+function placesLabel(n: number): string {
+  const mod10 = n % 10
+  const mod100 = n % 100
+  if (n === 1) return 'miejsce'
+  if (mod10 >= 2 && mod10 <= 4 && !(mod100 >= 12 && mod100 <= 14)) return 'miejsca'
+  return 'miejsc'
+}
+
+// Movement since the previous match: ▲ green up, ▼ red down, – unchanged, blank
+// when there is no prior ranking yet. Fixed-width so the names stay aligned.
+function Movement({ entry }: { entry: RankingEntry }) {
+  if (entry.previous_position == null) return <span className="w-7 shrink-0" aria-hidden="true" />
+  const delta = entry.previous_position - entry.position
+  if (delta === 0) {
+    return (
+      <span className="w-7 shrink-0 text-center text-xs text-muted/50" title="Bez zmian">
+        –
+      </span>
+    )
+  }
+  const up = delta > 0
+  return (
+    <span
+      className={`flex w-7 shrink-0 items-center justify-center gap-0.5 text-xs font-semibold tabular-nums ${
+        up ? 'text-emerald-600' : 'text-red-500'
+      }`}
+      title={up ? `Awans o ${delta}` : `Spadek o ${-delta}`}
+    >
+      <i className={`fas fa-caret-${up ? 'up' : 'down'}`} aria-hidden="true" />
+      {Math.abs(delta)}
+    </span>
+  )
 }
 
 // Mirrors rankings/show.html.erb.
@@ -35,6 +75,34 @@ export default function RankingPage() {
 
   const meEntry = data.find((entry) => entry.user.id === user?.id)
   const scrollToMe = () => meRowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+
+  // Prize zone: the top N places are "in the money" (N decided per season, see
+  // CurrentUser#rewarded_positions). Entries are sorted by position asc, so the
+  // zone is the contiguous prefix `position <= rewarded` — which also covers ties
+  // straddling the cutoff. cutoffPoints is the weakest score still in the zone;
+  // firstOutPoints is the best score just outside it.
+  const rewarded = user?.rewarded_positions ?? 0
+  const prizeCount = rewarded > 0 ? data.filter((entry) => entry.position <= rewarded).length : 0
+  const cutoffPoints = prizeCount > 0 ? data[prizeCount - 1].points : null
+  const firstOutPoints = prizeCount < data.length ? data[prizeCount]?.points ?? null : null
+
+  const meInPrize = !!meEntry && rewarded > 0 && meEntry.position <= rewarded
+  const meGap = meEntry && !meInPrize && cutoffPoints != null ? pointsDisplay(cutoffPoints - meEntry.points) : null
+
+  // A small contextual note on rows near the cutoff: the cushion for the weakest
+  // place still in the zone, or the points the nearest chasers need to break in.
+  // Only the closest few outside the zone get a note, so the tail stays quiet.
+  const zoneHint = (entry: RankingEntry, idx: number): { text: string; tone: string } | null => {
+    if (rewarded === 0 || cutoffPoints == null) return null
+    if (entry.position <= rewarded) {
+      if (firstOutPoints != null && entry.points === cutoffPoints) {
+        return { text: `bufor ${pointsDisplay(entry.points - firstOutPoints)} pkt`, tone: 'text-emerald-600' }
+      }
+      return null
+    }
+    if (idx > prizeCount + 4) return null
+    return { text: `+${pointsDisplay(cutoffPoints - entry.points)} do strefy`, tone: 'text-amber-600' }
+  }
 
   return (
     <>
@@ -70,6 +138,17 @@ export default function RankingPage() {
                   {meEntry.position} / {data.length}
                 </span>{' '}
                 · <span className="font-bold text-ink tabular-nums">{pointsDisplay(meEntry.points)}</span> pkt
+                {rewarded > 0 && (meInPrize || meGap != null) && (
+                  <span className="mt-0.5 block text-xs font-medium">
+                    {meInPrize ? (
+                      <span className="text-emerald-600">
+                        <i className="fas fa-trophy" aria-hidden="true" /> W strefie nagród
+                      </span>
+                    ) : (
+                      <span className="text-amber-600">+{meGap} pkt do strefy nagród</span>
+                    )}
+                  </span>
+                )}
               </span>
               <button type="button" className="btn btn-brand btn-sm shrink-0" onClick={scrollToMe}>
                 <i className="fas fa-location-arrow" aria-hidden="true" /> Pokaż mnie
@@ -77,35 +156,48 @@ export default function RankingPage() {
             </div>
           )}
           <ul className="card divide-y divide-line/60 overflow-hidden">
-            {data.map((entry) => {
+            {data.map((entry, idx) => {
               const me = user?.id === entry.user.id
-              const badge = BADGES[entry.position] ?? 'bg-surface text-muted'
+              const inPrize = rewarded > 0 && entry.position <= rewarded
+              const hint = zoneHint(entry, idx)
+              const accent = inPrize ? 'border-l-[3px] border-amber-400' : 'border-l-[3px] border-transparent'
+              const bg = me ? (drzewkoMode ? 'drzewko-flash' : 'bg-brand-tint') : inPrize ? 'bg-amber-50/50' : ''
               return (
-                <li
-                  key={entry.user.id}
-                  ref={me ? meRowRef : undefined}
-                  className={`flex items-center gap-3 px-4 py-3 ${
-                    me ? (drzewkoMode ? 'drzewko-flash' : 'bg-brand-tint') : ''
-                  }`}
-                >
-                  <span
-                    className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-bold tabular-nums ${badge}`}
+                <Fragment key={entry.user.id}>
+                  <li
+                    ref={me ? meRowRef : undefined}
+                    className={`flex items-center gap-2.5 px-4 py-3 ${accent} ${bg}`}
                   >
-                    {entry.position}
-                  </span>
-                  <span className="flex-1 truncate font-medium">
-                    <Link to={`/users/${entry.user.id}`} className="text-ink hover:text-brand">
-                      {entry.user.username}
-                    </Link>
-                    {me && <span className="ml-1 text-xs font-normal text-brand">(Ty)</span>}
-                  </span>
-                  <span className="text-right leading-tight">
-                    <span className="font-bold text-ink tabular-nums">
-                      {pointsDisplay(entry.points)} <span className="text-xs font-normal text-muted">pkt</span>
+                    <span
+                      className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-bold tabular-nums ${positionBadgeClass(
+                        entry.position,
+                        rewarded,
+                      )}`}
+                    >
+                      {entry.position}
                     </span>
-                    <span className="block text-xs text-muted">{entry.accuracy} trafień</span>
-                  </span>
-                </li>
+                    <Movement entry={entry} />
+                    <span className="flex-1 truncate font-medium">
+                      <Link to={`/users/${entry.user.id}`} className="text-ink hover:text-brand">
+                        {entry.user.username}
+                      </Link>
+                      {me && <span className="ml-1 text-xs font-normal text-brand">(Ty)</span>}
+                    </span>
+                    <span className="text-right leading-tight">
+                      <span className="font-bold text-ink tabular-nums">
+                        {pointsDisplay(entry.points)} <span className="text-xs font-normal text-muted">pkt</span>
+                      </span>
+                      <span className="block text-xs text-muted">{entry.accuracy} trafień</span>
+                      {hint && <span className={`block text-xs font-medium ${hint.tone}`}>{hint.text}</span>}
+                    </span>
+                  </li>
+                  {prizeCount > 0 && idx === prizeCount - 1 && idx < data.length - 1 && (
+                    <li className="flex items-center gap-2 bg-amber-50 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-amber-700">
+                      <i className="fas fa-trophy" aria-hidden="true" />
+                      Strefa nagród · {rewarded} {placesLabel(rewarded)}
+                    </li>
+                  )}
+                </Fragment>
               )
             })}
           </ul>

--- a/lib/typerek/ranking.rb
+++ b/lib/typerek/ranking.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Typerek
+  # Namespace for the participant ranking. Also holds the per-season "prize zone"
+  # size, which is otherwise pure configuration with no natural home.
+  module Ranking
+    # How many of the top positions are "in the money" this season — the prize
+    # zone the ranking UI highlights. It is decided once at the start of the
+    # season (this year 5, last year 4) and pinned via the REWARDED_POSITIONS env
+    # var at deploy time; defaults to 5. The client reads it through
+    # CurrentUser#rewarded_positions.
+    REWARDED_POSITIONS = Integer(ENV.fetch('REWARDED_POSITIONS', 5))
+  end
+end

--- a/lib/typerek/ranking/entry.rb
+++ b/lib/typerek/ranking/entry.rb
@@ -3,7 +3,9 @@
 module Typerek
   module Ranking
     # A single ranking row: the user along with their computed position, points
-    # and number of correct bets.
-    Entry = Struct.new(:user, :points, :accuracy, :position, keyword_init: true)
+    # and number of correct bets. `previous_position` is where they stood before
+    # the most recent finished match (for the movement arrow), or nil when there
+    # is no prior ranking to compare against yet.
+    Entry = Struct.new(:user, :points, :accuracy, :position, :previous_position, keyword_init: true)
   end
 end

--- a/lib/typerek/ranking/query.rb
+++ b/lib/typerek/ranking/query.rb
@@ -59,12 +59,14 @@ module Typerek
         end
 
         points = scored.map { |row| row[:points] }
+        previous = previous_positions_by_user_id
         scored.map do |row|
           Entry.new(
             user: row[:user],
             points: row[:points],
             accuracy: row[:accuracy],
-            position: points.index(row[:points]) + 1
+            position: points.index(row[:points]) + 1,
+            previous_position: previous[row[:user].id]
           )
         end
       end
@@ -76,6 +78,31 @@ module Typerek
       end
 
       private
+
+      # Each active user's position as it stood *before* the most recent finished
+      # match, keyed by user id — the baseline for the table's movement arrow.
+      # Points only come from finished matches, so subtracting a user's payout from
+      # that one match reconstructs the prior standing without replaying history.
+      # Returns {} (i.e. no arrows) until at least two matches have finished, since
+      # before the second there is no real prior ranking to compare against —
+      # everyone starts level.
+      def previous_positions_by_user_id
+        last_match = Match.finished.order(start: :desc).first
+        return {} if last_match.nil? || Match.finished.count < 2
+
+        previous = active_users.map do |user|
+          delta = user.answers.find { |answer| answer.match_id == last_match.id }&.point || 0
+          { user: user, points: (user.points - delta).round(2) }
+        end
+        previous.sort! do |a, b|
+          by_points = b[:points] <=> a[:points]
+          by_points.zero? ? a[:user].username.downcase <=> b[:user].username.downcase : by_points
+        end
+        previous_points = previous.map { |row| row[:points] }
+        previous.each_with_object({}) do |row, positions|
+          positions[row[:user].id] = previous_points.index(row[:points]) + 1
+        end
+      end
 
       def active_users
         @active_users ||= User.includes(answers: :match).active.to_a

--- a/spec/typerek/ranking/query_spec.rb
+++ b/spec/typerek/ranking/query_spec.rb
@@ -35,6 +35,34 @@ RSpec.describe Typerek::Ranking::Query do
       expect(entry.accuracy).to eq(1)
     end
 
+    it 'leaves previous_position nil until a second match has finished' do
+      amy = active_user('amy')
+      create(:answer, match: match, user: amy, result: :win_a)
+
+      entry = described_class.new.call.first
+
+      expect(entry.previous_position).to be_nil
+    end
+
+    it 'exposes the position before the most recent finished match as previous_position' do
+      earlier = create(:match, :winner_a, win_a: 6.0, start: 2.days.ago)
+      latest  = create(:match, :winner_a, win_a: 10.0, start: 1.day.ago)
+      amy = active_user('amy') # misses the earlier one, nails the latest -> 10.0
+      bob = active_user('bob') # nails the earlier one, misses the latest -> 6.0
+      create(:answer, match: earlier, user: amy, result: :tie)
+      create(:answer, match: latest,  user: amy, result: :win_a)
+      create(:answer, match: earlier, user: bob, result: :win_a)
+      create(:answer, match: latest,  user: bob, result: :tie)
+
+      result = described_class.new.call
+      amy_entry = result.find { |entry| entry.user == amy }
+      bob_entry = result.find { |entry| entry.user == bob }
+
+      # After both matches amy leads; before the latest match bob was ahead.
+      expect([amy_entry.position, bob_entry.position]).to eq([1, 2])
+      expect([amy_entry.previous_position, bob_entry.previous_position]).to eq([2, 1])
+    end
+
     it 'excludes users who have not accepted their invitation' do
       active_user('amy')
       create(:user, username: 'pending', invitation_accepted_at: nil)


### PR DESCRIPTION
The top-3 medals were hardcoded, but the number of rewarded places is decided per season (5 this year, 4 last year). Replace the fixed podium with a configurable "prize zone" of the top N and make the boundary, movement and gaps legible in both the table and the bump chart.

- Add Typerek::Ranking::REWARDED_POSITIONS (REWARDED_POSITIONS env, default 5); surface it on CurrentUser#rewarded_positions.
- Ranking table: prize-zone row tint + accent, a cutoff divider labelled with the seat count, amber badges for places 4..N (podium keeps gold/ silver/bronze), per-round movement arrows, and "+X to the zone" / "buffer X" hints around the cutoff plus prize status in the banner.
- Bump chart: dashed ReferenceLine at y=N marking the prize cutoff.
- Compute Entry#previous_position (standing before the most recent finished match) for the movement arrows.