### PR TITLE
Draw flag ring as an outset box-shadow so it doesn't shrink the flag

### DIFF
--- a/frontend/src/components/Flag.tsx
+++ b/frontend/src/components/Flag.tsx
@@ -5,17 +5,14 @@ import { flagCode } from '@/lib/flags'
 // (`fi fi-<code>`), so every country ships with the package — no per-team asset to
 // vendor when the schedule gains a new team. Sizing comes from `className`.
 //
-// The faint inset ring outlines the flag against light backgrounds — otherwise
-// mostly-white flags (e.g. Japan, a red circle on white) read as a floating dot.
-// A ring draws as a box-shadow, so it follows the rounded corners without nudging
-// the background-image sizing the way a `border` would.
-//
-// `bg-cover` overrides flag-icons' default `contain`: the boxes <Flag> is given
-// (~1.4 aspect) are a touch wider than the 4:3 sprite, so `contain` would letterbox
-// the flag and leave the ring floating outside it. `cover` fills the box edge to
-// edge (negligible crop), so the ring hugs the flag exactly.
+// The faint ring outlines the flag against light backgrounds — otherwise mostly-
+// white flags (e.g. Japan, a red circle on white) read as a floating dot. The ring
+// is *not* inset, so it's drawn as a box-shadow just outside the flag rather than
+// painted over its edge (which would make the flag look shrunk). `bg-cover`
+// overrides flag-icons' default `contain` so the sprite fills the slightly-wider
+// box edge to edge (negligible crop) and the ring hugs the flag exactly.
 export default function Flag({ team, className = '' }: { team: string; className?: string }) {
   const code = flagCode(team)
   if (!code) return null
-  return <span className={`fi fi-${code} bg-cover ring-1 ring-inset ring-black/10 ${className}`} aria-hidden="true" />
+  return <span className={`fi fi-${code} bg-cover ring-1 ring-black/10 ${className}`} aria-hidden="true" />
 }


### PR DESCRIPTION
The inset ring painted over the flag's edge, making it look ~1px smaller all around. Drop `ring-inset` so the ring sits just outside the flag instead.