### PR TITLE
Add dark mode (always / by the hour), toggled in settings

### DIFF
--- a/app/controllers/api/v1/profile_controller.rb
+++ b/app/controllers/api/v1/profile_controller.rb
@@ -28,15 +28,19 @@ module Api
 
       private
 
-      # Only known keys are accepted; values are coerced to booleans and merged
-      # into the existing settings bag, so a partial update leaves the rest intact.
+      # Only known keys are accepted and merged into the existing settings bag, so a
+      # partial update leaves the rest intact. The boolean flags are coerced to true/
+      # false; `theme` is a string and is only kept when it is one of the allowed
+      # values (an invalid value is dropped so it can't poison the stored bag).
       def settings_params
-        params.require(:settings).permit(
+        permitted = params.require(:settings).permit(
           :drzewko_mode, :bet_lock, :hide_odds, :hide_double_chance,
-          :push_enabled, :push_results, :push_reminders
-        ).to_h.transform_values do |value|
-          ActiveModel::Type::Boolean.new.cast(value)
-        end
+          :push_enabled, :push_results, :push_reminders, :theme
+        ).to_h
+
+        theme = permitted.delete('theme')
+        booleans = permitted.transform_values { |value| ActiveModel::Type::Boolean.new.cast(value) }
+        User::THEMES.include?(theme) ? booleans.merge('theme' => theme) : booleans
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,8 +13,15 @@ class User < ApplicationRecord
     'hide_double_chance' => false,
     'push_enabled' => false,
     'push_results' => true,
-    'push_reminders' => true
+    'push_reminders' => true,
+    # UI colour theme. 'light' is the default (dark mode off); 'dark' forces dark
+    # mode on; 'auto' lets the SPA switch by the clock (dark at night). Unlike the
+    # other settings this is a string, not a boolean — see THEMES and #theme.
+    'theme' => 'light'
   }.freeze
+
+  # Allowed values for the `theme` setting. Anything else falls back to 'light'.
+  THEMES = %w[light dark auto].freeze
 
   # Settings we surface a "Włączone przez N osób" count for on the settings screen.
   # The push sub-toggles are excluded: they default on, so a raw `= 'true'` count
@@ -68,7 +75,11 @@ class User < ApplicationRecord
   def self.settings_counts
     COUNTED_SETTINGS.index_with do |key|
       where("settings ->> ? = 'true'", key).count
-    end
+    end.merge(
+      # `theme` isn't a boolean: it counts users who turned dark mode on at all,
+      # i.e. either 'dark' (always) or 'auto' (by the clock).
+      'theme' => where("settings ->> 'theme' IN (?, ?)", 'dark', 'auto').count
+    )
   end
 
   def settings_with_defaults
@@ -106,5 +117,12 @@ class User < ApplicationRecord
 
   def push_reminders?
     settings_with_defaults['push_reminders'] != false
+  end
+
+  # Colour theme preference ('light' | 'dark' | 'auto'). Guards against a stale or
+  # malformed value in the jsonb bag by falling back to the default.
+  def theme
+    value = settings_with_defaults['theme']
+    THEMES.include?(value) ? value : 'light'
   end
 end

--- a/app/serializers/api/v1/current_user_serializer.rb
+++ b/app/serializers/api/v1/current_user_serializer.rb
@@ -25,7 +25,8 @@ module Api
             hide_double_chance: user.hide_double_chance?,
             push_enabled: user.push_enabled?,
             push_results: user.push_results?,
-            push_reminders: user.push_reminders?
+            push_reminders: user.push_reminders?,
+            theme: user.theme
           }
         }
       end

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,6 +19,27 @@
     <meta name="apple-mobile-web-app-title" content="Typerek" />
     <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" />
     <title>Typerek</title>
+
+    <!-- Anti-FOUC: apply the cached colour theme before the app loads so dark mode
+         doesn't flash light on every navigation. Mirrors src/lib/theme.ts (kept tiny
+         and dependency-free); the React app re-applies and keeps it in sync after. -->
+    <script>
+      (function () {
+        try {
+          var pref = localStorage.getItem('typerek.theme') || 'light'
+          var dark = pref === 'dark'
+          if (pref === 'auto') {
+            var h = new Date().getHours()
+            dark = h >= 20 || h < 7
+          }
+          if (dark) {
+            document.documentElement.classList.add('dark')
+            var meta = document.querySelector('meta[name="theme-color"]')
+            if (meta) meta.setAttribute('content', '#0F3D27')
+          }
+        } catch (e) {}
+      })()
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2,6 +2,8 @@
 // be generated automatically with openapi-typescript; for now they are kept in
 // sync by hand.
 
+import type { ThemePreference } from '@/lib/theme'
+
 export type BetType = 'win_a' | 'tie' | 'win_b' | 'win_tie_a' | 'win_tie_b' | 'not_tie'
 
 export interface Odds {
@@ -31,6 +33,8 @@ export interface UserSettings {
   // Which kinds of push the user wants (only relevant when push_enabled). Default on.
   push_results: boolean
   push_reminders: boolean
+  // Colour theme: 'light' (off), 'dark' (always), or 'auto' (dark at night).
+  theme: ThemePreference
 }
 
 // A registered Web Push device for the signed-in user (GET /push/subscriptions).

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -20,7 +20,7 @@ export default function Layout({ children }: { children: ReactNode }) {
 
   return (
     <div className="flex min-h-screen flex-col">
-      <header className="bg-brand text-white shadow-sm">
+      <header className="bg-header text-white shadow-sm">
         <nav className="container-app flex flex-wrap items-center justify-between gap-x-8 gap-y-2 py-3">
           <div className="flex w-full items-center justify-between lg:w-auto">
             <Link to="/" className="flex items-center gap-2 text-lg font-bold text-white hover:text-white">

--- a/frontend/src/components/MatchLine.tsx
+++ b/frontend/src/components/MatchLine.tsx
@@ -33,7 +33,7 @@ function Countdown({ start }: { start: string }) {
 
   const urgent = remaining < 30 * 60 * 1000
   return (
-    <span className={`text-[10px] font-bold leading-none ${urgent ? 'text-amber-600' : 'text-muted'}`}>
+    <span className={`text-[10px] font-bold leading-none ${urgent ? 'text-highlight-fg' : 'text-muted'}`}>
       za <span className="tabular-nums">{formatCountdown(remaining)}</span>
     </span>
   )
@@ -52,7 +52,7 @@ export default function MatchLine({ match, started }: { match: Match; started?: 
       <span className="flex w-14 shrink-0 flex-col gap-0.5">
         <span className="text-sm font-semibold tabular-nums text-muted">{formatTime(match.start)}</span>
         {live && (
-          <span className="inline-flex items-center gap-1 text-[10px] font-bold leading-none text-amber-600">
+          <span className="inline-flex items-center gap-1 text-[10px] font-bold leading-none text-highlight-fg">
             <span className="h-1.5 w-1.5 rounded-full bg-amber-500 motion-safe:animate-pulse" aria-hidden="true" />
             Trwa
           </span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,6 +8,45 @@
  */
 
 @layer base {
+  /* Semantic design tokens as space-separated RGB channels (consumed via
+     rgb(var(--x) / <alpha-value>) in tailwind.config.cjs). Light values mirror the
+     original hex palette 1:1. */
+  :root {
+    --ink: 29 36 32;          /* #1D2420 */
+    --muted: 95 106 109;      /* #5F6A6D */
+    --line: 228 228 228;      /* #E4E4E4 */
+    --surface: 236 237 238;   /* #ECEDEE */
+    --raised: 255 255 255;    /* #FFFFFF */
+    --header: 18 167 81;      /* #12A751 (brand green) */
+    --brand: 18 167 81;       /* #12A751 */
+    --brand-dark: 14 140 67;  /* #0E8C43 */
+    --brand-tint: 234 250 241; /* #EAFAF1 */
+    --danger: 250 106 106;    /* #FA6A6A */
+    --danger-tint: 253 239 239; /* #FDEFEF */
+    --highlight: 255 251 235; /* #FFFBEB amber-50 */
+    --highlight-fg: 180 83 9; /* #B45309 amber-700 */
+  }
+
+  /* Dark mode (toggled by the `dark` class on <html>; see src/lib/theme.ts). A warm
+     slate palette — deliberately not pure black — so text stays comfortable and
+     readable. Brand green is nudged brighter for contrast on the dark surfaces, and
+     the tints become dark, low-chroma chip backgrounds instead of light pastels. */
+  .dark {
+    --ink: 230 233 236;       /* #E6E9EC */
+    --muted: 151 161 170;     /* #97A1AA */
+    --line: 58 67 77;         /* #3A434D */
+    --surface: 24 29 35;      /* #181D23 page background */
+    --raised: 35 42 50;       /* #232A32 cards / inputs */
+    --header: 15 61 39;       /* #0F3D27 deep calm green */
+    --brand: 31 182 98;       /* #1FB662 */
+    --brand-dark: 24 154 81;  /* #189A51 */
+    --brand-tint: 28 58 41;   /* #1C3A29 */
+    --danger: 248 113 113;    /* #F87171 */
+    --danger-tint: 58 37 38;  /* #3A2526 */
+    --highlight: 58 46 22;    /* #3A2E16 muted warm-dark */
+    --highlight-fg: 252 211 77; /* #FCD34D amber-300 */
+  }
+
   html {
     -webkit-text-size-adjust: 100%;
     /* Always reserve the scrollbar gutter so switching between short pages (e.g.
@@ -32,15 +71,15 @@
   .container-narrow { @apply mx-auto w-full max-w-md px-4; }
 
   /* Cards */
-  .card { @apply rounded-xl bg-white shadow-card; }
+  .card { @apply rounded-xl bg-raised shadow-card; }
   .card-header { @apply flex items-center justify-between gap-3 border-b border-line/70 px-4 py-3 sm:px-5; }
   .card-body { @apply px-4 py-4 sm:px-5; }
 
   /* Buttons */
   .btn { @apply inline-flex cursor-pointer items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold leading-none transition-colors disabled:pointer-events-none disabled:opacity-50; }
   .btn-brand { @apply bg-brand text-white hover:bg-brand-dark; }
-  .btn-outline { @apply border border-brand bg-white text-brand hover:bg-brand-tint; }
-  .btn-ghost { @apply text-ink/70 hover:bg-black/5 hover:text-ink; }
+  .btn-outline { @apply border border-brand bg-raised text-brand hover:bg-brand-tint; }
+  .btn-ghost { @apply text-ink/70 hover:bg-black/5 hover:text-ink dark:hover:bg-white/10; }
   .btn-danger { @apply bg-danger text-white hover:opacity-90; }
   .btn-block { @apply w-full; }
   .btn-sm { @apply px-3 py-1.5 text-xs; }
@@ -50,11 +89,11 @@
   .badge-success { @apply bg-brand-tint text-brand; }
   .badge-warning { @apply bg-amber-100 text-amber-700; }
   .badge-danger { @apply bg-danger-tint text-danger; }
-  .badge-count { @apply inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-black/10 px-1.5 text-xs font-bold text-ink/70; }
+  .badge-count { @apply inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-black/10 px-1.5 text-xs font-bold text-ink/70 dark:bg-white/10; }
 
   /* Forms */
   .label { @apply mb-1 block text-sm font-semibold text-ink; }
-  .field { @apply w-full rounded-lg border border-line bg-white px-3 py-2 text-sm text-ink placeholder:text-muted focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/20 disabled:bg-surface disabled:text-muted; }
+  .field { @apply w-full rounded-lg border border-line bg-raised px-3 py-2 text-sm text-ink placeholder:text-muted focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/20 disabled:bg-surface disabled:text-muted; }
 
   /* Admin user list: a compact 2x2 card on mobile (user + status on top,
      payment + actions below) that flows into aligned columns with a header on >=sm. */
@@ -72,7 +111,7 @@
   .ur-status { grid-area: status; }
   .ur-pay { grid-area: pay; }
   .ur-actions { grid-area: actions; @apply flex items-center gap-1 justify-self-end; }
-  .btn-action { @apply inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted transition-colors hover:bg-black/5 hover:text-ink; }
+  .btn-action { @apply inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted transition-colors hover:bg-black/5 hover:text-ink dark:hover:bg-white/10; }
   .btn-action-danger { @apply hover:bg-danger-tint hover:text-danger; }
 
   /* Tabs */
@@ -88,7 +127,7 @@
   .bet { @apply flex flex-col items-center justify-center gap-0.5 rounded-lg border px-1 py-1.5 text-center leading-none transition-colors; }
   .bet-key { @apply text-[11px] font-bold uppercase tracking-wide; }
   .bet-odds { @apply text-xs font-semibold tabular-nums; }
-  .bet-idle { @apply border-brand/30 bg-white text-ink hover:border-brand hover:bg-brand-tint hover:text-ink; }
+  .bet-idle { @apply border-brand/30 bg-raised text-ink hover:border-brand hover:bg-brand-tint hover:text-ink; }
   .bet-locked { @apply pointer-events-none border-line bg-surface text-muted; }
   /* The viewer's pick before the result is known — neutral gray ("picked, undecided"). */
   .bet-pick { @apply border-[#969b9d] bg-[#969b9d] text-white shadow-sm; }
@@ -97,7 +136,7 @@
   /* Finished match: the viewer's pick that missed (light red). */
   .bet-miss { @apply border-danger/40 bg-danger-tint text-danger; }
   /* Padlock toggle next to the pills (LockToggle); brand-colored when locked. */
-  .bet-lock { @apply inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted transition-colors hover:bg-black/5 hover:text-ink disabled:pointer-events-none disabled:opacity-50; }
+  .bet-lock { @apply inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted transition-colors hover:bg-black/5 hover:text-ink disabled:pointer-events-none disabled:opacity-50 dark:hover:bg-white/10; }
   .bet-lock-on { @apply text-brand hover:text-brand; }
 }
 

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -2,6 +2,13 @@ import { createContext, useContext, useEffect, useState, type ReactNode } from '
 import api from '@/api/client'
 import { useAuth } from '@/auth/AuthContext'
 import type { UserSettings } from '@/api/types'
+import {
+  applyTheme,
+  readStoredPreference,
+  resolveTheme,
+  storePreference,
+  type ThemePreference,
+} from '@/lib/theme'
 
 // Client-side view of the per-user UI preferences. The source of truth lives on
 // the backend (User#settings); this context mirrors it in camelCase and writes
@@ -26,6 +33,8 @@ interface Settings {
   // Which kinds of push the user wants (only meaningful when pushEnabled). Default on.
   pushResults: boolean
   pushReminders: boolean
+  // Colour theme: 'light' (dark mode off), 'dark' (always on), 'auto' (dark at night).
+  theme: ThemePreference
 }
 
 const DEFAULTS: Settings = {
@@ -36,6 +45,7 @@ const DEFAULTS: Settings = {
   pushEnabled: false,
   pushResults: true,
   pushReminders: true,
+  theme: 'light',
 }
 
 // Map between the server shape (snake_case, the API contract) and ours (camelCase).
@@ -48,6 +58,11 @@ function fromServer(settings: UserSettings | undefined): Settings {
     pushEnabled: settings?.push_enabled ?? DEFAULTS.pushEnabled,
     pushResults: settings?.push_results ?? DEFAULTS.pushResults,
     pushReminders: settings?.push_reminders ?? DEFAULTS.pushReminders,
+    // While signed out (no server settings), keep whatever theme the anti-FOUC
+    // bootstrap already painted from the localStorage cache, so the sign-in screen
+    // doesn't flash from the cached dark back to light. Once a user loads, the
+    // server value (always present — it defaults to 'light') takes over.
+    theme: settings?.theme ?? readStoredPreference(),
   }
 }
 
@@ -61,6 +76,7 @@ interface SettingsState extends Settings {
   setPushEnabled: (value: boolean) => Promise<void>
   setPushResults: (value: boolean) => Promise<void>
   setPushReminders: (value: boolean) => Promise<void>
+  setTheme: (value: ThemePreference) => Promise<void>
 }
 
 const SettingsContext = createContext<SettingsState | undefined>(undefined)
@@ -73,6 +89,25 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     setSettings(fromServer(user?.settings))
   }, [user])
+
+  // Apply the colour theme whenever the preference changes, and cache it so the
+  // anti-FOUC bootstrap in index.html paints the right theme on the next load.
+  // For 'auto', re-resolve on a timer (and when the tab becomes visible) so the
+  // switch follows the clock across the 20:00 / 07:00 boundary without a reload.
+  useEffect(() => {
+    const theme = settings.theme
+    const sync = () => applyTheme(resolveTheme(theme))
+    sync()
+    storePreference(theme)
+
+    if (theme !== 'auto') return
+    const interval = window.setInterval(sync, 60_000)
+    document.addEventListener('visibilitychange', sync)
+    return () => {
+      window.clearInterval(interval)
+      document.removeEventListener('visibilitychange', sync)
+    }
+  }, [settings.theme])
 
   // Update locally first (snappy toggle), then persist. The PATCH returns just the
   // updated settings, so we fold them into the cached user instead of paying for a
@@ -95,6 +130,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     setPushEnabled: (pushEnabled) => persist({ pushEnabled }, { push_enabled: pushEnabled }),
     setPushResults: (pushResults) => persist({ pushResults }, { push_results: pushResults }),
     setPushReminders: (pushReminders) => persist({ pushReminders }, { push_reminders: pushReminders }),
+    setTheme: (theme) => persist({ theme }, { theme }),
   }
 
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -1,0 +1,72 @@
+// Colour-theme logic, shared by the React app (SettingsProvider) and the tiny
+// anti-FOUC bootstrap script in index.html. Keep this dependency-free so it can be
+// inlined/duplicated there without pulling anything in.
+
+// User preference, persisted server-side (User#settings['theme']) and mirrored here.
+//   'light' — dark mode off (default)
+//   'dark'  — dark mode always on
+//   'auto'  — dark at night, light during the day (see the window below)
+export type ThemePreference = 'light' | 'dark' | 'auto'
+
+// What's actually painted once a preference is resolved against the clock.
+export type ResolvedTheme = 'light' | 'dark'
+
+// "Depending on the hour" window: dark from 20:00 up to (but not including) 07:00.
+// A fixed window, the same for everyone.
+export const DARK_START_HOUR = 20
+export const DARK_END_HOUR = 7
+
+// localStorage cache of the preference, read by the bootstrap script before React
+// mounts so the correct theme is applied without a flash of the wrong one.
+export const STORAGE_KEY = 'typerek.theme'
+
+const THEMES: ThemePreference[] = ['light', 'dark', 'auto']
+
+export function isThemePreference(value: unknown): value is ThemePreference {
+  return typeof value === 'string' && (THEMES as string[]).includes(value)
+}
+
+// True when the given moment falls inside the night window (dark in 'auto' mode).
+export function isNightAt(date: Date): boolean {
+  const hour = date.getHours()
+  return hour >= DARK_START_HOUR || hour < DARK_END_HOUR
+}
+
+// Turn a preference into the theme to actually paint right now.
+export function resolveTheme(pref: ThemePreference, now: Date = new Date()): ResolvedTheme {
+  if (pref === 'auto') return isNightAt(now) ? 'dark' : 'light'
+  return pref
+}
+
+// Top-bar colour per theme — must match --header in index.css. Also drives the
+// mobile browser chrome (<meta name="theme-color">) so it matches the header.
+export const HEADER_COLOR: Record<ResolvedTheme, string> = {
+  light: '#12A751',
+  dark: '#0F3D27',
+}
+
+// Flip the `dark` class on <html> (all CSS variables key off it) and keep the
+// mobile address-bar colour in sync with the header.
+export function applyTheme(resolved: ResolvedTheme): void {
+  document.documentElement.classList.toggle('dark', resolved === 'dark')
+  const meta = document.querySelector('meta[name="theme-color"]')
+  if (meta) meta.setAttribute('content', HEADER_COLOR[resolved])
+}
+
+export function readStoredPreference(): ThemePreference {
+  try {
+    const value = localStorage.getItem(STORAGE_KEY)
+    return isThemePreference(value) ? value : 'light'
+  } catch {
+    // localStorage can throw (private mode / disabled storage) — fall back to light.
+    return 'light'
+  }
+}
+
+export function storePreference(pref: ThemePreference): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, pref)
+  } catch {
+    // Best-effort cache; ignore storage failures.
+  }
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -55,7 +55,7 @@ export default function HomePage() {
         Możemy zmieniać typy do momentu rozpoczęcia spotkania. Gdy mecz się rozpocznie, widzimy typy
         wszystkich uczestników dla danego meczu. Nie możemy wtedy modyfikować swojego wyboru.
       </p>
-      <div className="rounded-lg bg-amber-50 p-3 text-sm text-amber-800">
+      <div className="rounded-lg bg-highlight p-3 text-sm text-highlight-fg">
         <strong>Uwaga!</strong> W meczach fazy pucharowej typujemy wyniki tylko do 90. minuty spotkania. Typ
         „remis” jest jak najbardziej poprawny. Oznacza to, że drużyny po rozegraniu regulaminowych 90 minut
         będą miały dogrywkę.

--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -56,7 +56,7 @@ export default function MatchPage() {
         </div>
         {live && (
           <p className="mt-3 text-center">
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-bold text-amber-700">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-highlight px-2.5 py-0.5 text-xs font-bold text-highlight-fg">
               <span className="h-2 w-2 rounded-full bg-amber-500 motion-safe:animate-pulse" aria-hidden="true" />
               Trwa
             </span>

--- a/frontend/src/pages/MatchesPage.tsx
+++ b/frontend/src/pages/MatchesPage.tsx
@@ -25,7 +25,7 @@ function MatchRow({ match }: { match: Match }) {
   const live = localStarted && !match.finished
   return (
     <div
-      className={`flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-5${live ? ' bg-amber-50/70' : ''}`}
+      className={`flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-5${live ? ' bg-highlight/70' : ''}`}
     >
       <MatchLine match={match} started={localStarted} />
       {/* Pills, plus a fixed padlock slot on the right when the feature is

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -12,10 +12,15 @@ import type { RankingEntry } from '@/api/types'
 // Colour of the round position badge. Gold / silver / bronze for the podium, a
 // softer amber for the rest of the prize zone (positions 4..N), plain otherwise.
 function positionBadgeClass(position: number, rewarded: number): string {
-  if (position === 1) return 'bg-yellow-400 text-white'
-  if (position === 2) return 'bg-gray-300 text-ink'
-  if (position === 3) return 'bg-amber-600 text-white'
-  if (position <= rewarded) return 'bg-amber-100 text-amber-700 ring-1 ring-amber-300'
+  // Medals use slightly deeper, less saturated shades in dark mode so they don't
+  // glare on the dark page. Silver keeps fixed-dark text (text-ink would flip to
+  // near-white in dark mode and vanish on the light-grey chip).
+  if (position === 1) return 'bg-yellow-400 text-white dark:bg-yellow-500 dark:text-yellow-950'
+  if (position === 2) return 'bg-gray-300 text-gray-900 dark:bg-slate-400 dark:text-slate-950'
+  if (position === 3) return 'bg-amber-600 text-white dark:bg-amber-700'
+  if (position <= rewarded) {
+    return 'bg-highlight text-highlight-fg ring-1 ring-highlight-fg/30'
+  }
   return 'bg-surface text-muted'
 }
 
@@ -96,12 +101,12 @@ export default function RankingPage() {
     if (rewarded === 0 || cutoffPoints == null) return null
     if (entry.position <= rewarded) {
       if (firstOutPoints != null && entry.points === cutoffPoints) {
-        return { text: `bufor ${pointsDisplay(entry.points - firstOutPoints)} pkt`, tone: 'text-emerald-600' }
+        return { text: `bufor ${pointsDisplay(entry.points - firstOutPoints)} pkt`, tone: 'text-emerald-600 dark:text-emerald-400' }
       }
       return null
     }
     if (idx > prizeCount + 4) return null
-    return { text: `+${pointsDisplay(cutoffPoints - entry.points)} do strefy`, tone: 'text-amber-600' }
+    return { text: `+${pointsDisplay(cutoffPoints - entry.points)} do strefy`, tone: 'text-amber-600 dark:text-amber-400' }
   }
 
   return (
@@ -141,11 +146,11 @@ export default function RankingPage() {
                 {rewarded > 0 && (meInPrize || meGap != null) && (
                   <span className="mt-0.5 block text-xs font-medium">
                     {meInPrize ? (
-                      <span className="text-emerald-600">
+                      <span className="text-emerald-600 dark:text-emerald-400">
                         <i className="fas fa-trophy" aria-hidden="true" /> W strefie nagród
                       </span>
                     ) : (
-                      <span className="text-amber-600">+{meGap} pkt do strefy nagród</span>
+                      <span className="text-amber-600 dark:text-amber-400">+{meGap} pkt do strefy nagród</span>
                     )}
                   </span>
                 )}
@@ -161,7 +166,7 @@ export default function RankingPage() {
               const inPrize = rewarded > 0 && entry.position <= rewarded
               const hint = zoneHint(entry, idx)
               const accent = inPrize ? 'border-l-[3px] border-amber-400' : 'border-l-[3px] border-transparent'
-              const bg = me ? (drzewkoMode ? 'drzewko-flash' : 'bg-brand-tint') : inPrize ? 'bg-amber-50/50' : ''
+              const bg = me ? (drzewkoMode ? 'drzewko-flash' : 'bg-brand-tint') : inPrize ? 'bg-highlight/60' : ''
               return (
                 <Fragment key={entry.user.id}>
                   <li
@@ -192,7 +197,7 @@ export default function RankingPage() {
                     </span>
                   </li>
                   {prizeCount > 0 && idx === prizeCount - 1 && idx < data.length - 1 && (
-                    <li className="flex items-center gap-2 bg-amber-50 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-amber-700">
+                    <li className="flex items-center gap-2 bg-highlight px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-highlight-fg">
                       <i className="fas fa-trophy" aria-hidden="true" />
                       Strefa nagród · {rewarded} {placesLabel(rewarded)}
                     </li>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -5,6 +5,18 @@ import { usePushSubscription, pushSupported } from '@/lib/usePushSubscription'
 import { useDocumentTitle } from '@/lib/useDocumentTitle'
 import Alert from '@/components/Alert'
 import type { PushDevice } from '@/api/types'
+import { DARK_END_HOUR, DARK_START_HOUR, type ThemePreference } from '@/lib/theme'
+
+// The three dark-mode choices, in display order. 'light' is the default (off).
+const THEME_OPTIONS: { value: ThemePreference; title: string; hint: string }[] = [
+  { value: 'light', title: 'Wyłączony', hint: 'Zawsze jasny motyw.' },
+  { value: 'dark', title: 'Zawsze włączony', hint: 'Ciemny motyw przez cały czas.' },
+  {
+    value: 'auto',
+    title: 'Zależnie od godziny',
+    hint: `Ciemny wieczorem i w nocy (${DARK_START_HOUR}:00–${DARK_END_HOUR}:00), jasny w dzień.`,
+  },
+]
 
 // Number of users with each setting switched on, keyed by the server setting name.
 type SettingsStats = {
@@ -13,6 +25,8 @@ type SettingsStats = {
   hide_odds: number
   hide_double_chance: number
   push_enabled: number
+  // How many users have dark mode on (theme 'dark' or 'auto').
+  theme: number
 }
 
 // Polish accusative of "osoba" for the "Włączone przez N osób" hint:
@@ -62,6 +76,8 @@ function formatDeviceDate(iso: string): string {
 
 export default function SettingsPage() {
   const {
+    theme,
+    setTheme,
     drzewkoMode,
     setDrzewkoMode,
     betLock,
@@ -127,6 +143,20 @@ export default function SettingsPage() {
     void set(checked).finally(refreshStats)
   }
 
+  // Theme is the only non-boolean setting: the usage count tracks "dark mode on"
+  // (dark or auto), so only crossing the light <-> (dark|auto) line changes it.
+  // Bump optimistically on that crossing, then reconcile with the server.
+  const handleThemeChange = (next: ThemePreference) => {
+    const wasOn = theme !== 'light'
+    const nowOn = next !== 'light'
+    if (wasOn !== nowOn) {
+      setStats((prev) =>
+        prev ? { ...prev, theme: Math.max(0, prev.theme + (nowOn ? 1 : -1)) } : prev,
+      )
+    }
+    void setTheme(next).finally(refreshStats)
+  }
+
   // Per-device opt-in: enabling asks for browser permission and subscribes *this*
   // device; disabling tears that subscription down. The backend derives the account's
   // push_enabled flag from whether any device remains, so we just refresh the usage
@@ -164,6 +194,33 @@ export default function SettingsPage() {
           {pushError}
         </Alert>
       )}
+
+      <section className="card mb-4 px-4 py-4 sm:px-5">
+        <fieldset>
+          <legend className="font-semibold text-ink">Ciemny motyw</legend>
+          <p className="mt-0.5 text-muted">
+            Ciemniejsze kolory aplikacji. „Zależnie od godziny” włącza je wieczorem i w nocy.
+          </p>
+          <div className="mt-3 space-y-2">
+            {THEME_OPTIONS.map((option) => (
+              <label key={option.value} className="flex cursor-pointer items-start gap-3">
+                <input
+                  type="radio"
+                  name="theme"
+                  className="mt-0.5 h-5 w-5 shrink-0 accent-brand"
+                  checked={theme === option.value}
+                  onChange={() => handleThemeChange(option.value)}
+                />
+                <span className="leading-snug">
+                  <span className="block font-medium text-ink">{option.title}</span>
+                  <span className="block text-muted">{option.hint}</span>
+                </span>
+              </label>
+            ))}
+          </div>
+          <UsageHint count={stats?.theme} />
+        </fieldset>
+      </section>
 
       <section className="card divide-y divide-line/60">
         <div>

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -46,7 +46,7 @@ export default function UserProfilePage() {
                   <div
                     key={match.id}
                     className={`flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-5${
-                      match.started && !match.finished ? ' bg-amber-50/70' : ''
+                      match.started && !match.finished ? ' bg-highlight/70' : ''
                     }`}
                   >
                     <MatchLine match={match} />

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -4,22 +4,40 @@
 // SPA sources instead of the ERB views).
 module.exports = {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
+  // Dark mode is toggled by adding the `dark` class to <html> (see src/lib/theme.ts).
+  darkMode: 'class',
   theme: {
     extend: {
+      // Semantic colours are CSS variables (space-separated RGB channels) so a single
+      // `.dark` override in index.css flips the whole UI. The `<alpha-value>` slot
+      // keeps Tailwind's opacity modifiers working (e.g. border-line/70, text-ink/70).
       colors: {
         brand: {
-          DEFAULT: '#12A751',
-          dark: '#0E8C43',
-          tint: '#EAFAF1',
+          DEFAULT: 'rgb(var(--brand) / <alpha-value>)',
+          dark: 'rgb(var(--brand-dark) / <alpha-value>)',
+          tint: 'rgb(var(--brand-tint) / <alpha-value>)',
         },
         danger: {
-          DEFAULT: '#FA6A6A',
-          tint: '#FDEFEF',
+          DEFAULT: 'rgb(var(--danger) / <alpha-value>)',
+          tint: 'rgb(var(--danger-tint) / <alpha-value>)',
         },
-        ink: '#1D2420',
-        muted: '#5F6A6D',
-        line: '#E4E4E4',
-        surface: '#ECEDEE',
+        ink: 'rgb(var(--ink) / <alpha-value>)',
+        muted: 'rgb(var(--muted) / <alpha-value>)',
+        line: 'rgb(var(--line) / <alpha-value>)',
+        surface: 'rgb(var(--surface) / <alpha-value>)',
+        // Raised surfaces (cards, inputs) — white in light mode, a lighter slate than
+        // the page background in dark mode. Replaces hardcoded `bg-white`.
+        raised: 'rgb(var(--raised) / <alpha-value>)',
+        // The top navigation bar. Bright brand green in light mode, a deep calm green
+        // in dark mode (the bright brand green glares on a dark page).
+        header: 'rgb(var(--header) / <alpha-value>)',
+        // Warm "highlight" used for live matches, the prize zone and notice banners.
+        // Light amber in light mode, a muted warm-dark + light-amber text in dark mode,
+        // so these accents stop glaring while staying readable.
+        highlight: {
+          DEFAULT: 'rgb(var(--highlight) / <alpha-value>)',
+          fg: 'rgb(var(--highlight-fg) / <alpha-value>)',
+        },
       },
       fontFamily: {
         sans: ['Roboto', 'ui-sans-serif', 'system-ui', 'Arial', 'sans-serif'],

--- a/spec/requests/api/v1/profile_spec.rb
+++ b/spec/requests/api/v1/profile_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'API V1 Profile', type: :request do
       expect(json['settings']).to eq(
         'drzewko_mode' => false, 'bet_lock' => false, 'hide_odds' => false,
         'hide_double_chance' => false, 'push_enabled' => false,
-        'push_results' => true, 'push_reminders' => true
+        'push_results' => true, 'push_reminders' => true, 'theme' => 'light'
       )
     end
 
@@ -36,14 +36,16 @@ RSpec.describe 'API V1 Profile', type: :request do
 
     it 'returns how many users have each setting enabled' do
       create(:user, :active, settings: { 'drzewko_mode' => true, 'bet_lock' => true })
-      create(:user, :active, settings: { 'drzewko_mode' => true })
+      create(:user, :active, settings: { 'drzewko_mode' => true, 'theme' => 'dark' })
+      create(:user, :active, settings: { 'theme' => 'auto' })
+      create(:user, :active, settings: { 'theme' => 'light' })
 
       get '/api/v1/me/settings/stats', headers: auth_headers(user)
 
       expect(response).to have_http_status(:ok)
       expect(json).to eq(
         'drzewko_mode' => 2, 'bet_lock' => 1, 'hide_odds' => 0,
-        'hide_double_chance' => 0, 'push_enabled' => 0
+        'hide_double_chance' => 0, 'push_enabled' => 0, 'theme' => 2
       )
     end
 
@@ -64,9 +66,27 @@ RSpec.describe 'API V1 Profile', type: :request do
       expect(json['settings']).to eq(
         'drzewko_mode' => false, 'bet_lock' => true, 'hide_odds' => false,
         'hide_double_chance' => false, 'push_enabled' => false,
-        'push_results' => true, 'push_reminders' => true
+        'push_results' => true, 'push_reminders' => true, 'theme' => 'light'
       )
       expect(user.reload.bet_lock?).to be(true)
+    end
+
+    it 'accepts a valid theme preference' do
+      patch '/api/v1/me/settings', params: { settings: { theme: 'auto' } }, headers: auth_headers(user), as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json['settings']).to include('theme' => 'auto')
+      expect(user.reload.theme).to eq('auto')
+    end
+
+    it 'ignores an invalid theme and keeps the current one' do
+      user.update_column(:settings, { 'theme' => 'dark' })
+
+      patch '/api/v1/me/settings', params: { settings: { theme: 'neon' } }, headers: auth_headers(user), as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json['settings']).to include('theme' => 'dark')
+      expect(user.reload.theme).to eq('dark')
     end
 
     it 'returns 401 without a token' do


### PR DESCRIPTION
Dark mode is a new per-user `theme` setting ('light' | 'dark' | 'auto'), persisted in User#settings and mirrored to the SPA. 'dark' is always on, 'auto' switches by the clock (dark 20:00-07:00). The palette is a warm slate (not pure black) so text stays readable.

Theming works by turning the semantic Tailwind tokens into CSS variables (space-separated RGB channels) flipped by a `dark` class on <html>, so most of the UI follows automatically. A tiny inline script in index.html applies the cached theme before React mounts (anti-FOUC) and keeps the mobile theme-color in sync with the header.

- New `header` token: brand green in light, deep calm green in dark (the bright brand green glared on a dark page).
- New `highlight` token for live matches, the prize zone and notice banners, so the light-amber accents stop glaring and stay readable in dark mode.
- Ranking: medals use deeper shades in dark; prize-zone backgrounds no longer wash out the rows, keeping "N trafień" readable.
- Settings: dark-mode option shows a "Włączone przez N osób" usage count (theme 'dark' or 'auto').