### PR TITLE
Add favourite users: star in ranking, highlight in ranking and match …

### DIFF
--- a/app/controllers/api/v1/profile_controller.rb
+++ b/app/controllers/api/v1/profile_controller.rb
@@ -31,16 +31,30 @@ module Api
       # Only known keys are accepted and merged into the existing settings bag, so a
       # partial update leaves the rest intact. The boolean flags are coerced to true/
       # false; `theme` is a string and is only kept when it is one of the allowed
-      # values (an invalid value is dropped so it can't poison the stored bag).
+      # values (an invalid value is dropped so it can't poison the stored bag);
+      # `favorite_user_ids` is an array of user ids, normalised to unique positive
+      # integers with the user's own id stripped (you can't favourite yourself).
       def settings_params
         permitted = params.require(:settings).permit(
           :drzewko_mode, :bet_lock, :hide_odds, :hide_double_chance,
-          :push_enabled, :push_results, :push_reminders, :theme
+          :push_enabled, :push_results, :push_reminders, :theme,
+          favorite_user_ids: []
         ).to_h
 
+        result = {}
+
         theme = permitted.delete('theme')
-        booleans = permitted.transform_values { |value| ActiveModel::Type::Boolean.new.cast(value) }
-        User::THEMES.include?(theme) ? booleans.merge('theme' => theme) : booleans
+        result['theme'] = theme if User::THEMES.include?(theme)
+
+        if permitted.key?('favorite_user_ids')
+          result['favorite_user_ids'] = Array(permitted.delete('favorite_user_ids'))
+                                        .map(&:to_i)
+                                        .reject { |id| id <= 0 || id == current_user.id }
+                                        .uniq
+        end
+
+        permitted.each { |key, value| result[key] = ActiveModel::Type::Boolean.new.cast(value) }
+        result
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,11 @@ class User < ApplicationRecord
     # UI colour theme. 'light' is the default (dark mode off); 'dark' forces dark
     # mode on; 'auto' lets the SPA switch by the clock (dark at night). Unlike the
     # other settings this is a string, not a boolean — see THEMES and #theme.
-    'theme' => 'light'
+    'theme' => 'light',
+    # IDs of users this user starred as favourites in the ranking. Highlighted in
+    # the ranking and in a match's participant ("typy") list. Unlike the others
+    # this is an array, not a scalar — see #favorite_user_ids.
+    'favorite_user_ids' => []
   }.freeze
 
   # Allowed values for the `theme` setting. Anything else falls back to 'light'.
@@ -124,5 +128,12 @@ class User < ApplicationRecord
   def theme
     value = settings_with_defaults['theme']
     THEMES.include?(value) ? value : 'light'
+  end
+
+  # IDs of the users this user starred as favourites. Coerces the stored jsonb to a
+  # plain array of integers so a malformed value (e.g. nil or strings) can't break
+  # the ranking/match views that highlight these users.
+  def favorite_user_ids
+    Array(settings_with_defaults['favorite_user_ids']).map(&:to_i)
   end
 end

--- a/app/serializers/api/v1/current_user_serializer.rb
+++ b/app/serializers/api/v1/current_user_serializer.rb
@@ -26,7 +26,8 @@ module Api
             push_enabled: user.push_enabled?,
             push_results: user.push_results?,
             push_reminders: user.push_reminders?,
-            theme: user.theme
+            theme: user.theme,
+            favorite_user_ids: user.favorite_user_ids
           }
         }
       end

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -35,6 +35,9 @@ export interface UserSettings {
   push_reminders: boolean
   // Colour theme: 'light' (off), 'dark' (always), or 'auto' (dark at night).
   theme: ThemePreference
+  // IDs of users the viewer starred as favourites in the ranking. They are
+  // highlighted in the ranking and in a match's participant ("typy") list.
+  favorite_user_ids: number[]
 }
 
 // A registered Web Push device for the signed-in user (GET /push/subscriptions).

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -35,6 +35,10 @@ interface Settings {
   pushReminders: boolean
   // Colour theme: 'light' (dark mode off), 'dark' (always on), 'auto' (dark at night).
   theme: ThemePreference
+  // IDs of users the viewer starred as favourites in the ranking. They are
+  // highlighted in the ranking and in a match's participant list. Toggled from the
+  // ranking via toggleFavorite; persisted server-side like the other preferences.
+  favoriteUserIds: number[]
 }
 
 const DEFAULTS: Settings = {
@@ -46,6 +50,7 @@ const DEFAULTS: Settings = {
   pushResults: true,
   pushReminders: true,
   theme: 'light',
+  favoriteUserIds: [],
 }
 
 // Map between the server shape (snake_case, the API contract) and ours (camelCase).
@@ -63,6 +68,7 @@ function fromServer(settings: UserSettings | undefined): Settings {
     // doesn't flash from the cached dark back to light. Once a user loads, the
     // server value (always present — it defaults to 'light') takes over.
     theme: settings?.theme ?? readStoredPreference(),
+    favoriteUserIds: settings?.favorite_user_ids ?? DEFAULTS.favoriteUserIds,
   }
 }
 
@@ -77,6 +83,8 @@ interface SettingsState extends Settings {
   setPushResults: (value: boolean) => Promise<void>
   setPushReminders: (value: boolean) => Promise<void>
   setTheme: (value: ThemePreference) => Promise<void>
+  // Add or remove a user from the viewer's favourites (starred in the ranking).
+  toggleFavorite: (userId: number) => Promise<void>
 }
 
 const SettingsContext = createContext<SettingsState | undefined>(undefined)
@@ -131,6 +139,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     setPushResults: (pushResults) => persist({ pushResults }, { push_results: pushResults }),
     setPushReminders: (pushReminders) => persist({ pushReminders }, { push_reminders: pushReminders }),
     setTheme: (theme) => persist({ theme }, { theme }),
+    toggleFavorite: (userId) => {
+      const next = settings.favoriteUserIds.includes(userId)
+        ? settings.favoriteUserIds.filter((id) => id !== userId)
+        : [...settings.favoriteUserIds, userId]
+      return persist({ favoriteUserIds: next }, { favorite_user_ids: next })
+    },
   }
 
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>

--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -15,9 +15,10 @@ import { useSettings } from '@/lib/settings'
 export default function MatchPage() {
   const { id = '' } = useParams()
   const { isAdmin } = useAuth()
-  const { hideOdds } = useSettings()
+  const { hideOdds, favoriteUserIds } = useSettings()
   const { data: match, isLoading, isError } = useMatch(id)
   const placeBet = usePlaceBet()
+  const favorites = new Set(favoriteUserIds)
 
   useDocumentTitle(match ? `${match.team_a} – ${match.team_b}` : undefined)
 
@@ -98,12 +99,23 @@ export default function MatchPage() {
             </div>
           )}
           <div className="divide-y divide-line/60">
-            {match.participants.map((participant) => (
+            {match.participants.map((participant) => {
+              const fav = favorites.has(participant.user.id)
+              return (
               <div
                 key={participant.user.id}
-                className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-5"
+                className={`flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-5 ${
+                  fav ? 'bg-amber-100/80 dark:bg-amber-500/10' : ''
+                }`}
               >
-                <div className="font-medium">
+                <div className={`flex items-center gap-1.5 ${fav ? 'font-semibold' : 'font-medium'}`}>
+                  {fav && (
+                    <i
+                      className="fas fa-star text-xs text-yellow-400"
+                      aria-label="Ulubiony"
+                      title="Ulubiony"
+                    />
+                  )}
                   <Link to={`/users/${participant.user.id}`} className="text-ink hover:text-brand">
                     {participant.user.username}
                   </Link>
@@ -135,7 +147,8 @@ export default function MatchPage() {
                   </div>
                 )}
               </div>
-            ))}
+              )
+            })}
           </div>
         </section>
       )}

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -63,7 +63,7 @@ function Movement({ entry }: { entry: RankingEntry }) {
 export default function RankingPage() {
   const { data, isLoading, isError } = useRanking()
   const { user } = useAuth()
-  const { drzewkoMode } = useSettings()
+  const { drzewkoMode, favoriteUserIds, toggleFavorite } = useSettings()
   const meRowRef = useRef<HTMLLIElement>(null)
 
   // The active subpage lives in the URL (?view=chart) so a refresh or shared link
@@ -80,6 +80,7 @@ export default function RankingPage() {
 
   const meEntry = data.find((entry) => entry.user.id === user?.id)
   const scrollToMe = () => meRowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  const favorites = new Set(favoriteUserIds)
 
   // Prize zone: the top N places are "in the money" (N decided per season, see
   // CurrentUser#rewarded_positions). Entries are sorted by position asc, so the
@@ -164,9 +165,22 @@ export default function RankingPage() {
             {data.map((entry, idx) => {
               const me = user?.id === entry.user.id
               const inPrize = rewarded > 0 && entry.position <= rewarded
+              const fav = !me && favorites.has(entry.user.id)
               const hint = zoneHint(entry, idx)
-              const accent = inPrize ? 'border-l-[3px] border-amber-400' : 'border-l-[3px] border-transparent'
-              const bg = me ? (drzewkoMode ? 'drzewko-flash' : 'bg-brand-tint') : inPrize ? 'bg-highlight/60' : ''
+              // Favourites and prize-zone rows both get a left accent; a favourite
+              // takes precedence on the background tint (a touch deeper amber than
+              // the zone) so a starred row stands out even when it's also in the zone.
+              const accent =
+                inPrize || fav ? 'border-l-[3px] border-amber-400' : 'border-l-[3px] border-transparent'
+              const bg = me
+                ? drzewkoMode
+                  ? 'drzewko-flash'
+                  : 'bg-brand-tint'
+                : fav
+                  ? 'bg-amber-100/80 dark:bg-amber-500/10'
+                  : inPrize
+                    ? 'bg-highlight/60'
+                    : ''
               return (
                 <Fragment key={entry.user.id}>
                   <li
@@ -182,7 +196,7 @@ export default function RankingPage() {
                       {entry.position}
                     </span>
                     <Movement entry={entry} />
-                    <span className="flex-1 truncate font-medium">
+                    <span className={`flex-1 truncate ${fav ? 'font-semibold' : 'font-medium'}`}>
                       <Link to={`/users/${entry.user.id}`} className="text-ink hover:text-brand">
                         {entry.user.username}
                       </Link>
@@ -195,6 +209,26 @@ export default function RankingPage() {
                       <span className="block text-xs text-muted">{entry.accuracy} trafień</span>
                       {hint && <span className={`block text-xs font-medium ${hint.tone}`}>{hint.text}</span>}
                     </span>
+                    {me ? (
+                      <span className="w-8 shrink-0" aria-hidden="true" />
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => void toggleFavorite(entry.user.id)}
+                        aria-pressed={fav}
+                        aria-label={
+                          fav
+                            ? `Usuń ${entry.user.username} z ulubionych`
+                            : `Dodaj ${entry.user.username} do ulubionych`
+                        }
+                        title={fav ? 'Usuń z ulubionych' : 'Dodaj do ulubionych'}
+                        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-base transition-colors hover:bg-black/5 dark:hover:bg-white/10 ${
+                          fav ? 'text-yellow-400 hover:text-yellow-500' : 'text-muted/40 hover:text-yellow-400'
+                        }`}
+                      >
+                        <i className={`${fav ? 'fas' : 'far'} fa-star`} aria-hidden="true" />
+                      </button>
+                    )}
                   </li>
                   {prizeCount > 0 && idx === prizeCount - 1 && idx < data.length - 1 && (
                     <li className="flex items-center gap-2 bg-highlight px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-highlight-fg">

--- a/spec/requests/api/v1/profile_spec.rb
+++ b/spec/requests/api/v1/profile_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe 'API V1 Profile', type: :request do
       expect(json['settings']).to eq(
         'drzewko_mode' => false, 'bet_lock' => false, 'hide_odds' => false,
         'hide_double_chance' => false, 'push_enabled' => false,
-        'push_results' => true, 'push_reminders' => true, 'theme' => 'light'
+        'push_results' => true, 'push_reminders' => true, 'theme' => 'light',
+        'favorite_user_ids' => []
       )
     end
 
@@ -66,7 +67,8 @@ RSpec.describe 'API V1 Profile', type: :request do
       expect(json['settings']).to eq(
         'drzewko_mode' => false, 'bet_lock' => true, 'hide_odds' => false,
         'hide_double_chance' => false, 'push_enabled' => false,
-        'push_results' => true, 'push_reminders' => true, 'theme' => 'light'
+        'push_results' => true, 'push_reminders' => true, 'theme' => 'light',
+        'favorite_user_ids' => []
       )
       expect(user.reload.bet_lock?).to be(true)
     end
@@ -87,6 +89,31 @@ RSpec.describe 'API V1 Profile', type: :request do
       expect(response).to have_http_status(:ok)
       expect(json['settings']).to include('theme' => 'dark')
       expect(user.reload.theme).to eq('dark')
+    end
+
+    it 'stores favourite user ids, deduped and without the user itself' do
+      a = create(:user, :active)
+      b = create(:user, :active)
+
+      patch '/api/v1/me/settings',
+            params: { settings: { favorite_user_ids: [a.id, b.id, a.id, user.id] } },
+            headers: auth_headers(user), as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json['settings']['favorite_user_ids']).to contain_exactly(a.id, b.id)
+      expect(user.reload.favorite_user_ids).to contain_exactly(a.id, b.id)
+    end
+
+    it 'clears favourites when given an empty list' do
+      other = create(:user, :active)
+      user.update_column(:settings, { 'favorite_user_ids' => [other.id] })
+
+      patch '/api/v1/me/settings', params: { settings: { favorite_user_ids: [] } },
+            headers: auth_headers(user), as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json['settings']['favorite_user_ids']).to eq([])
+      expect(user.reload.favorite_user_ids).to eq([])
     end
 
     it 'returns 401 without a token' do


### PR DESCRIPTION
…detail

Users can star favourites from the ranking. Starred users stand out in the ranking (gold star, amber row) and in a match's participant ("typy") list. Stored in the per-user settings jsonb (favorite_user_ids) so they persist across devices, flowing through the existing settings plumbing.