### PR TITLE
Keep your own row visible under the favourites-only filter

### DIFF
--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -32,11 +32,12 @@ export default function MatchPage() {
   const scored = match.finished ? new Set(winningBets(match.result_a, match.result_b)) : null
   const live = match.started && !match.finished
   // "Favourites only" lets you pull your starred players out of a long participant
-  // list without scrolling; it stacks with the chart's result filter.
+  // list without scrolling (your own row stays too); it stacks with the chart's
+  // result filter.
   const hasFavorites = (match.participants ?? []).some((p) => favorites.has(p.user.id))
   const visibleParticipants = (match.participants ?? [])
     .filter((p) => selectedResult === null || p.result === selectedResult)
-    .filter((p) => !favoritesOnly || favorites.has(p.user.id))
+    .filter((p) => !favoritesOnly || favorites.has(p.user.id) || p.user.id === user?.id)
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -107,14 +107,15 @@ export default function RankingPage() {
 
   // Quick find (by username, accent-insensitive — see fold) plus an optional
   // "favourites only" filter, so you can pull your starred players together
-  // without scrolling. Either one narrows the table, so both drop the prize-zone
-  // divider and the cutoff hints, which only make sense against the full,
-  // contiguous ranking.
+  // without scrolling. Favourites-only keeps your own row visible too, so you can
+  // see where you stand among them. Either filter narrows the table, so both drop
+  // the prize-zone divider and the cutoff hints, which only make sense against the
+  // full, contiguous ranking.
   const folded = fold(query.trim())
   const filtering = folded !== '' || favoritesOnly
   const visible = data.filter(
     (entry) =>
-      (!favoritesOnly || favorites.has(entry.user.id)) &&
+      (!favoritesOnly || favorites.has(entry.user.id) || entry.user.id === user?.id) &&
       (folded === '' || fold(entry.user.username).includes(folded)),
   )
 


### PR DESCRIPTION
When "Tylko ulubieni" is on, also show the current user alongside their starred players in both the ranking and a match's participant list, so you can see where you stand among them. hasFavorites still keys off real favourites, so the toggle won't appear just to show yourself alone.