### PR TITLE
Align your own row in a match's participant list

### DIFF
--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -145,7 +145,11 @@ export default function MatchPage() {
                 }`}
               >
                 <div className={`flex items-center gap-1.5 ${fav ? 'font-semibold' : 'font-medium'}`}>
-                  {!me && (
+                  {/* Reserve the star's slot for your own row (you can't favourite
+                      yourself) so every username lines up. */}
+                  {me ? (
+                    <span className="h-6 w-6 shrink-0" aria-hidden="true" />
+                  ) : (
                     <button
                       type="button"
                       onClick={() => void toggleFavorite(participant.user.id)}


### PR DESCRIPTION
The favourite star is a left-side prefix, but it's skipped for your own row (you can't favourite yourself), which shifted your username out of line with everyone else. Reserve the star's slot with a same-width spacer so all names line up — same approach the ranking uses for the "me" row.