### PR TITLE
Add hits ranking, perfect score, ranking-ordered typy and virtual pla…

### DIFF
--- a/app/controllers/api/v1/profile_controller.rb
+++ b/app/controllers/api/v1/profile_controller.rb
@@ -36,7 +36,7 @@ module Api
       # integers with the user's own id stripped (you can't favourite yourself).
       def settings_params
         permitted = params.require(:settings).permit(
-          :drzewko_mode, :bet_lock,
+          :drzewko_mode, :bet_lock, :match_order_by_ranking, :virtual_players,
           :push_enabled, :push_results, :push_reminders, :theme,
           favorite_user_ids: []
         ).to_h

--- a/app/controllers/api/v1/rankings_controller.rb
+++ b/app/controllers/api/v1/rankings_controller.rb
@@ -9,7 +9,17 @@ module Api
           [query::CACHE_KEY, query.cache_version],
           expires_in: 1.day
         ) do
-          RankingEntrySerializer.many(query.new.call).to_json
+          {
+            entries: RankingEntrySerializer.many(query.new.call),
+            # The season's point ceiling (a flawless tipster), so the client can
+            # show how far the field is from perfect. Depends only on finished
+            # matches, so it shares the ranking's cache fingerprint.
+            perfect_score: Match.perfect_score,
+            # Three naive benchmark strategies, scored over the finished matches. An
+            # opt-in client overlay (the virtual_players setting); always computed
+            # here since it shares the ranking's cache fingerprint and is cheap.
+            virtual_players: Typerek::Ranking::VirtualPlayers.call
+          }.to_json
         end
         render json: json
       end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -53,4 +53,19 @@ class Match < ApplicationRecord
       %w[tie win_tie_a win_tie_b]
     end
   end
+
+  # The most points a single perfect bet on this match could have scored: the best
+  # odds among the outcomes that actually won (see #winning_list). 0.0 while the
+  # match is unfinished or when none of the winning outcomes has odds set.
+  def max_point
+    return 0.0 unless finished?
+
+    winning_list.filter_map { |result| send(result) }.max&.round(2) || 0.0
+  end
+
+  # The theoretical ceiling for the whole season: what a flawless tipster who hit
+  # the best-paying correct outcome on every finished match would have scored.
+  def self.perfect_score
+    finished.sum(&:max_point).round(2)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,13 @@ class User < ApplicationRecord
     # IDs of users this user starred as favourites in the ranking. Highlighted in
     # the ranking and in a match's participant ("typy") list. Unlike the others
     # this is an array, not a scalar — see #favorite_user_ids.
-    'favorite_user_ids' => []
+    'favorite_user_ids' => [],
+    # Order a match's participant ("typy") list by ranking position instead of
+    # alphabetically, so the standings are easy to read off after a match. Opt-in.
+    'match_order_by_ranking' => false,
+    # Show three naive benchmark "players" (always-favourite / always-underdog /
+    # always-draw) interleaved in the ranking, to compare against. Opt-in.
+    'virtual_players' => false
   }.freeze
 
   # Allowed values for the `theme` setting. Anything else falls back to 'light'.
@@ -28,7 +34,7 @@ class User < ApplicationRecord
   # Settings we surface a "Włączone przez N osób" count for on the settings screen.
   # The push sub-toggles are excluded: they default on, so a raw `= 'true'` count
   # would be meaningless for them.
-  COUNTED_SETTINGS = %w[drzewko_mode bet_lock push_enabled].freeze
+  COUNTED_SETTINGS = %w[drzewko_mode bet_lock push_enabled match_order_by_ranking virtual_players].freeze
 
   has_secure_password validations: false
 
@@ -94,6 +100,14 @@ class User < ApplicationRecord
 
   def bet_lock?
     settings_with_defaults['bet_lock'] == true
+  end
+
+  def match_order_by_ranking?
+    settings_with_defaults['match_order_by_ranking'] == true
+  end
+
+  def virtual_players?
+    settings_with_defaults['virtual_players'] == true
   end
 
   def push_enabled?

--- a/app/serializers/api/v1/current_user_serializer.rb
+++ b/app/serializers/api/v1/current_user_serializer.rb
@@ -25,7 +25,9 @@ module Api
             push_results: user.push_results?,
             push_reminders: user.push_reminders?,
             theme: user.theme,
-            favorite_user_ids: user.favorite_user_ids
+            favorite_user_ids: user.favorite_user_ids,
+            match_order_by_ranking: user.match_order_by_ranking?,
+            virtual_players: user.virtual_players?
           }
         }
       end

--- a/app/serializers/api/v1/match_detail_serializer.rb
+++ b/app/serializers/api/v1/match_detail_serializer.rb
@@ -13,11 +13,17 @@ module Api
 
       def self.participants(match)
         answers = match.answers.group_by(&:user_id).transform_values(&:first)
+        # Each participant's current ranking position, so the client can optionally
+        # order the list by standings (the match_order_by_ranking setting). Read from
+        # the cached standings map — every active user has an entry. Default order
+        # stays alphabetical; the client re-sorts when the setting is on.
+        standings = Typerek::Ranking::Query.standings
         User.active.order(:username).map do |user|
           answer = answers[user.id]
           {
             user: { id: user.id, username: user.username },
-            result: answer&.result
+            result: answer&.result,
+            position: standings.dig(user.id, :position)
           }
         end
       end

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -10,7 +10,7 @@ import type {
   Match,
   MatchDetail,
   MatchList,
-  RankingEntry,
+  Ranking,
   RankingHistory,
   User,
   UserProfile,
@@ -59,7 +59,7 @@ export function useMatch(id: number | string) {
 export function useRanking() {
   return useQuery({
     queryKey: queryKeys.ranking,
-    queryFn: () => api.get<RankingEntry[]>('/ranking'),
+    queryFn: () => api.get<Ranking>('/ranking'),
   })
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -34,6 +34,10 @@ export interface UserSettings {
   // IDs of users the viewer starred as favourites in the ranking. They are
   // highlighted in the ranking and in a match's participant ("typy") list.
   favorite_user_ids: number[]
+  // Order a match's participant list by ranking position instead of alphabetically.
+  match_order_by_ranking: boolean
+  // Show the naive benchmark "players" interleaved in the ranking.
+  virtual_players: boolean
 }
 
 // A registered Web Push device for the signed-in user (GET /push/subscriptions).
@@ -84,6 +88,9 @@ export interface Match {
 export interface Participant {
   user: { id: number; username: string }
   result: BetType | null
+  // The participant's current ranking position, used to optionally order the list
+  // by standings (the match_order_by_ranking setting). null if not ranked.
+  position: number | null
 }
 
 export interface MatchDetail extends Match {
@@ -109,6 +116,24 @@ export interface RankingEntry {
   user: { id: number; username: string }
   points: number
   accuracy: number
+}
+
+// A naive benchmark strategy scored over the finished matches, shown interleaved
+// in the ranking when the virtual_players setting is on. Has no user account.
+export interface VirtualPlayer {
+  key: string
+  username: string
+  points: number
+  accuracy: number
+}
+
+export interface Ranking {
+  entries: RankingEntry[]
+  // The season's point ceiling — what a flawless tipster could have scored on the
+  // finished matches. 0 until at least one match has finished. Used to show each
+  // player's points as a share of the maximum obtainable.
+  perfect_score: number
+  virtual_players: VirtualPlayer[]
 }
 
 export interface UserProfileMatch extends Match {

--- a/frontend/src/lib/ranking.ts
+++ b/frontend/src/lib/ranking.ts
@@ -1,0 +1,37 @@
+// Which column the ranking table is ordered by. 'points' is the canonical,
+// prize-deciding order (mirrors Typerek::Ranking::Query on the backend); 'hits'
+// re-ranks by the number of correct bets ("trafienia") as an alternative view.
+export type RankSort = 'points' | 'hits'
+
+export function parseRankSort(param: string | null): RankSort {
+  return param === 'hits' ? 'hits' : 'points'
+}
+
+// The minimal shape rankEntries needs. RankingEntry satisfies it, and so will the
+// virtual benchmark players added later — both can be ranked by the same code.
+interface Rankable {
+  user: { username: string }
+  points: number
+  accuracy: number
+}
+
+// Re-rank entries client-side by the chosen key, mirroring the server's order:
+// the key descending, ties broken by username ascending, and shared positions for
+// equal key values (1, 1, 3). Ordering by 'hits' falls back to points (then
+// username) so equal-accuracy players keep a stable, sensible order, but the
+// *position* is shared for the same hit count. For 'points' this reproduces
+// Typerek::Ranking::Query exactly, so callers can recompute positions after
+// inserting extra rows (e.g. virtual players) without diverging from the backend.
+export function rankEntries<T extends Rankable>(entries: T[], sort: RankSort): (T & { position: number })[] {
+  const key = (entry: Rankable) => (sort === 'hits' ? entry.accuracy : entry.points)
+  const sorted = [...entries].sort((a, b) => {
+    const byKey = key(b) - key(a)
+    if (byKey !== 0) return byKey
+    if (sort === 'hits' && b.points !== a.points) return b.points - a.points
+    const an = a.user.username.toLowerCase()
+    const bn = b.user.username.toLowerCase()
+    return an < bn ? -1 : an > bn ? 1 : 0
+  })
+  const values = sorted.map(key)
+  return sorted.map((entry, index) => ({ ...entry, position: values.indexOf(values[index]) + 1 }))
+}

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -33,6 +33,11 @@ interface Settings {
   // highlighted in the ranking and in a match's participant list. Toggled from the
   // ranking via toggleFavorite; persisted server-side like the other preferences.
   favoriteUserIds: number[]
+  // Order a match's participant list by ranking position instead of alphabetically.
+  // Opt-in: off by default, toggled from the settings screen.
+  matchOrderByRanking: boolean
+  // Interleave the naive benchmark "players" into the ranking. Opt-in.
+  virtualPlayers: boolean
 }
 
 const DEFAULTS: Settings = {
@@ -43,6 +48,8 @@ const DEFAULTS: Settings = {
   pushReminders: true,
   theme: 'light',
   favoriteUserIds: [],
+  matchOrderByRanking: false,
+  virtualPlayers: false,
 }
 
 // Map between the server shape (snake_case, the API contract) and ours (camelCase).
@@ -59,6 +66,8 @@ function fromServer(settings: UserSettings | undefined): Settings {
     // server value (always present — it defaults to 'light') takes over.
     theme: settings?.theme ?? readStoredPreference(),
     favoriteUserIds: settings?.favorite_user_ids ?? DEFAULTS.favoriteUserIds,
+    matchOrderByRanking: settings?.match_order_by_ranking ?? DEFAULTS.matchOrderByRanking,
+    virtualPlayers: settings?.virtual_players ?? DEFAULTS.virtualPlayers,
   }
 }
 
@@ -73,6 +82,8 @@ interface SettingsState extends Settings {
   setTheme: (value: ThemePreference) => Promise<void>
   // Add or remove a user from the viewer's favourites (starred in the ranking).
   toggleFavorite: (userId: number) => Promise<void>
+  setMatchOrderByRanking: (value: boolean) => Promise<void>
+  setVirtualPlayers: (value: boolean) => Promise<void>
 }
 
 const SettingsContext = createContext<SettingsState | undefined>(undefined)
@@ -130,6 +141,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         : [...settings.favoriteUserIds, userId]
       return persist({ favoriteUserIds: next }, { favorite_user_ids: next })
     },
+    setMatchOrderByRanking: (matchOrderByRanking) =>
+      persist({ matchOrderByRanking }, { match_order_by_ranking: matchOrderByRanking }),
+    setVirtualPlayers: (virtualPlayers) =>
+      persist({ virtualPlayers }, { virtual_players: virtualPlayers }),
   }
 
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>

--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -17,7 +17,7 @@ import { useSettings } from '@/lib/settings'
 export default function MatchPage() {
   const { id = '' } = useParams()
   const { isAdmin, user } = useAuth()
-  const { favoriteUserIds, toggleFavorite } = useSettings()
+  const { favoriteUserIds, toggleFavorite, matchOrderByRanking } = useSettings()
   const { data: match, isLoading, isError } = useMatch(id)
   const placeBet = usePlaceBet()
   const favorites = new Set(favoriteUserIds)
@@ -38,6 +38,12 @@ export default function MatchPage() {
   const visibleParticipants = (match.participants ?? [])
     .filter((p) => selectedResult === null || p.result === selectedResult)
     .filter((p) => !favoritesOnly || favorites.has(p.user.id) || p.user.id === user?.id)
+  // Opt-in: order the list by ranking position instead of the server's alphabetical
+  // order, so you can read the standings off after a match. Unranked players (no
+  // position) fall to the bottom; ties keep the alphabetical order (stable sort).
+  const orderedParticipants = matchOrderByRanking
+    ? [...visibleParticipants].sort((a, b) => (a.position ?? Infinity) - (b.position ?? Infinity))
+    : visibleParticipants
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
@@ -131,10 +137,10 @@ export default function MatchPage() {
             </div>
           )}
           <div className="divide-y divide-line/60">
-            {visibleParticipants.length === 0 && (
+            {orderedParticipants.length === 0 && (
               <p className="px-4 py-6 text-center text-sm text-muted">Brak uczestników do pokazania.</p>
             )}
-            {visibleParticipants.map((participant) => {
+            {orderedParticipants.map((participant) => {
               const me = participant.user.id === user?.id
               const fav = !me && favorites.has(participant.user.id)
               return (
@@ -145,6 +151,13 @@ export default function MatchPage() {
                 }`}
               >
                 <div className={`flex items-center gap-1.5 ${fav ? 'font-semibold' : 'font-medium'}`}>
+                  {/* When ordering by ranking, lead each row with its position so the
+                      standings read off at a glance. */}
+                  {matchOrderByRanking && (
+                    <span className="w-6 shrink-0 text-right text-xs font-semibold tabular-nums text-muted">
+                      {participant.position ?? '—'}
+                    </span>
+                  )}
                   {/* Reserve the star's slot for your own row (you can't favourite
                       yourself) so every username lines up. */}
                   {me ? (

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -8,6 +8,7 @@ import RankingPointsChart from '@/components/RankingPointsChart'
 import { pointsDisplay } from '@/lib/format'
 import { useSettings } from '@/lib/settings'
 import { useDocumentTitle } from '@/lib/useDocumentTitle'
+import { rankEntries, parseRankSort, type RankSort } from '@/lib/ranking'
 import type { RankingEntry } from '@/api/types'
 
 // Colour of the round position badge. Gold / silver / bronze for the podium, a
@@ -71,6 +72,10 @@ function fold(value: string): string {
     .replace(/ł/g, 'l')
 }
 
+// A ranking table row: a real entry, or a virtual benchmark player (virtualKey
+// set, with a negative sentinel user id and no account to link to).
+type RankRow = RankingEntry & { virtualKey?: string }
+
 type View = 'table' | 'chart' | 'points'
 
 function parseView(param: string | null): View {
@@ -83,24 +88,65 @@ function parseView(param: string | null): View {
 export default function RankingPage() {
   const { data, isLoading, isError } = useRanking()
   const { user } = useAuth()
-  const { drzewkoMode, favoriteUserIds, toggleFavorite } = useSettings()
+  const { drzewkoMode, favoriteUserIds, toggleFavorite, virtualPlayers } = useSettings()
   const meRowRef = useRef<HTMLLIElement>(null)
   const [query, setQuery] = useState('')
   const [favoritesOnly, setFavoritesOnly] = useState(false)
 
-  // The active subpage lives in the URL (?view=chart) so a refresh or shared link
-  // keeps you on the same tab — same pattern as MatchesPage (?status=finished).
+  // The active subpage and the table sort both live in the URL (?view=chart&sort=hits)
+  // so a refresh or shared link keeps the same tab and ordering — same pattern as
+  // MatchesPage (?status=finished). The defaults (table / points) are left off the URL.
   const [searchParams, setSearchParams] = useSearchParams()
   const view = parseView(searchParams.get('view'))
-  const selectView = (next: View) =>
-    setSearchParams(next === 'table' ? {} : { view: next }, { replace: true })
+  const sort = parseRankSort(searchParams.get('sort'))
+  const updateParams = (next: { view?: View; sort?: RankSort }) => {
+    const nextView = next.view ?? view
+    const nextSort = next.sort ?? sort
+    const params: Record<string, string> = {}
+    if (nextView !== 'table') params.view = nextView
+    if (nextSort !== 'points') params.sort = nextSort
+    setSearchParams(params, { replace: true })
+  }
+  const selectView = (next: View) => updateParams({ view: next })
+  const selectSort = (next: RankSort) => updateParams({ sort: next })
 
   useDocumentTitle('Ranking')
 
   if (isLoading) return <Loading />
   if (isError || !data) return <ErrorBox />
 
-  const meEntry = data.find((entry) => entry.user.id === user?.id)
+  const entries = data.entries
+  const perfectScore = data.perfect_score
+  // Each player's points as a share of the season's ceiling (see Match.perfect_score),
+  // shown in parentheses next to their points. null while nothing has finished yet,
+  // so we never divide by zero or show a meaningless 0%.
+  const perfectShare = (points: number): string | null =>
+    perfectScore > 0 ? `${Math.round((points / perfectScore) * 100)}%` : null
+
+  // The naive benchmark "players" are mapped into the same row shape as real
+  // entries so they can be ranked and rendered together. They have no account, so
+  // they carry a negative sentinel id (never equal to a real user or the viewer)
+  // and a virtualKey to drive their distinct, account-less rendering.
+  const showVirtual = virtualPlayers && data.virtual_players.length > 0
+  const virtualRows: RankRow[] = data.virtual_players.map((vp, index) => ({
+    position: 0,
+    previous_position: null,
+    user: { id: -(index + 1), username: vp.username },
+    points: vp.points,
+    accuracy: vp.accuracy,
+    virtualKey: vp.key,
+  }))
+
+  // 'hits' re-ranks by number of correct bets; adding virtual players shifts
+  // everyone's place. Either makes the order "augmented" — a display-only view that
+  // recomputes positions client-side and drops the points-only chrome (movement
+  // arrows and the prize zone, the latter via rewarded being forced to 0 below).
+  // Plain points order with no virtual players keeps the server's ranking as-is.
+  const augmented = sort === 'hits' || showVirtual
+  const base: RankRow[] = showVirtual ? [...entries, ...virtualRows] : entries
+  const ranked: RankRow[] = augmented ? rankEntries(base, sort) : entries
+
+  const meEntry = ranked.find((entry) => entry.user.id === user?.id)
   const scrollToMe = () => meRowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
   const favorites = new Set(favoriteUserIds)
   const hasFavorites = favorites.size > 0
@@ -113,7 +159,7 @@ export default function RankingPage() {
   // full, contiguous ranking.
   const folded = fold(query.trim())
   const filtering = folded !== '' || favoritesOnly
-  const visible = data.filter(
+  const visible = ranked.filter(
     (entry) =>
       (!favoritesOnly || favorites.has(entry.user.id) || entry.user.id === user?.id) &&
       (folded === '' || fold(entry.user.username).includes(folded)),
@@ -124,10 +170,13 @@ export default function RankingPage() {
   // zone is the contiguous prefix `position <= rewarded` — which also covers ties
   // straddling the cutoff. cutoffPoints is the weakest score still in the zone;
   // firstOutPoints is the best score just outside it.
-  const rewarded = user?.rewarded_positions ?? 0
-  const prizeCount = rewarded > 0 ? data.filter((entry) => entry.position <= rewarded).length : 0
-  const cutoffPoints = prizeCount > 0 ? data[prizeCount - 1].points : null
-  const firstOutPoints = prizeCount < data.length ? data[prizeCount]?.points ?? null : null
+  // The prize zone is a points-only concept, so an augmented ordering disables it
+  // wholesale by forcing rewarded to 0 (cascades through prizeCount, the hints and
+  // the badge colours). It always reads from `entries`, the canonical points order.
+  const rewarded = augmented ? 0 : user?.rewarded_positions ?? 0
+  const prizeCount = rewarded > 0 ? entries.filter((entry) => entry.position <= rewarded).length : 0
+  const cutoffPoints = prizeCount > 0 ? entries[prizeCount - 1].points : null
+  const firstOutPoints = prizeCount < entries.length ? entries[prizeCount]?.points ?? null : null
 
   const meInPrize = !!meEntry && rewarded > 0 && meEntry.position <= rewarded
   const meGap = meEntry && !meInPrize && cutoffPoints != null ? pointsDisplay(cutoffPoints - meEntry.points) : null
@@ -151,7 +200,7 @@ export default function RankingPage() {
     <>
       <h1 className="mb-4 flex items-center gap-2">
         <i className="fas fa-trophy text-brand" aria-hidden="true" /> Ranking{' '}
-        <span className="badge-count">{data.length}</span>
+        <span className="badge-count">{entries.length}</span>
       </h1>
 
       <div className="mb-5 flex border-b border-line">
@@ -180,14 +229,43 @@ export default function RankingPage() {
 
       {view === 'table' ? (
         <div className="mx-auto max-w-xl">
+          <div className="mb-4 flex items-center gap-2">
+            <span className="text-sm font-medium text-muted">Sortuj:</span>
+            <div className="inline-flex rounded-full bg-surface p-0.5">
+              {(
+                [
+                  ['points', 'Punkty'],
+                  ['hits', 'Trafienia'],
+                ] as const
+              ).map(([value, label]) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => selectSort(value)}
+                  aria-pressed={sort === value}
+                  className={`rounded-full px-3 py-1.5 text-sm font-medium transition-colors ${
+                    sort === value ? 'bg-brand text-white shadow-sm' : 'text-muted hover:text-ink'
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
           {meEntry && (
             <div className="card card-body mb-4 flex items-center justify-between gap-3 border border-brand bg-brand-tint">
               <span className="leading-tight">
                 <i className="fas fa-star text-brand" aria-hidden="true" /> Twoja pozycja:{' '}
                 <span className="font-bold text-ink">
-                  {meEntry.position} / {data.length}
+                  {meEntry.position} / {entries.length}
                 </span>{' '}
                 · <span className="font-bold text-ink tabular-nums">{pointsDisplay(meEntry.points)}</span> pkt
+                {perfectShare(meEntry.points) && (
+                  <span className="text-muted">
+                    {' '}
+                    ({perfectShare(meEntry.points)} z {pointsDisplay(perfectScore)} pkt)
+                  </span>
+                )}
                 {rewarded > 0 && (meInPrize || meGap != null) && (
                   <span className="mt-0.5 block text-xs font-medium">
                     {meInPrize ? (
@@ -258,8 +336,9 @@ export default function RankingPage() {
           <ul className="card divide-y divide-line/60 overflow-hidden">
             {visible.map((entry, idx) => {
               const me = user?.id === entry.user.id
+              const virtual = entry.virtualKey != null
               const inPrize = rewarded > 0 && entry.position <= rewarded
-              const fav = !me && favorites.has(entry.user.id)
+              const fav = !me && !virtual && favorites.has(entry.user.id)
               const hint = filtering ? null : zoneHint(entry, idx)
               // Favourites and prize-zone rows both get a left accent; a favourite
               // takes precedence on the background tint (a touch deeper amber than
@@ -274,7 +353,9 @@ export default function RankingPage() {
                   ? 'bg-amber-100/80 dark:bg-amber-500/10'
                   : inPrize
                     ? 'bg-highlight/60'
-                    : ''
+                    : virtual
+                      ? 'bg-surface/50'
+                      : ''
               return (
                 <Fragment key={entry.user.id}>
                   <li
@@ -289,21 +370,36 @@ export default function RankingPage() {
                     >
                       {entry.position}
                     </span>
-                    <Movement entry={entry} />
+                    {augmented ? null : <Movement entry={entry} />}
                     <span className={`flex-1 truncate ${fav ? 'font-semibold' : 'font-medium'}`}>
-                      <Link to={`/users/${entry.user.id}`} className="text-ink hover:text-brand">
-                        {entry.user.username}
-                      </Link>
+                      {virtual ? (
+                        <span className="inline-flex items-center gap-1.5 text-muted">
+                          <i className="fas fa-robot" aria-hidden="true" />
+                          <span className="italic">{entry.user.username}</span>
+                          <span className="rounded bg-surface px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted">
+                            wirtualny
+                          </span>
+                        </span>
+                      ) : (
+                        <Link to={`/users/${entry.user.id}`} className="text-ink hover:text-brand">
+                          {entry.user.username}
+                        </Link>
+                      )}
                       {me && <span className="ml-1 text-xs font-normal text-brand">(Ty)</span>}
                     </span>
                     <span className="text-right leading-tight">
                       <span className="font-bold text-ink tabular-nums">
                         {pointsDisplay(entry.points)} <span className="text-xs font-normal text-muted">pkt</span>
+                        {perfectShare(entry.points) && (
+                          <span className="ml-1 text-xs font-normal text-muted tabular-nums">
+                            ({perfectShare(entry.points)})
+                          </span>
+                        )}
                       </span>
                       <span className="block text-xs text-muted">{entry.accuracy} trafień</span>
                       {hint && <span className={`block text-xs font-medium ${hint.tone}`}>{hint.text}</span>}
                     </span>
-                    {me ? (
+                    {me || virtual ? (
                       <span className="w-8 shrink-0" aria-hidden="true" />
                     ) : (
                       <button
@@ -324,7 +420,7 @@ export default function RankingPage() {
                       </button>
                     )}
                   </li>
-                  {!filtering && prizeCount > 0 && idx === prizeCount - 1 && idx < data.length - 1 && (
+                  {!filtering && prizeCount > 0 && idx === prizeCount - 1 && idx < entries.length - 1 && (
                     <li className="flex items-center gap-2 bg-highlight px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-highlight-fg">
                       <i className="fas fa-trophy" aria-hidden="true" />
                       Strefa nagród · {rewarded} {placesLabel(rewarded)}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -23,6 +23,8 @@ type SettingsStats = {
   drzewko_mode: number
   bet_lock: number
   push_enabled: number
+  match_order_by_ranking: number
+  virtual_players: number
   // How many users have dark mode on (theme 'dark' or 'auto').
   theme: number
 }
@@ -80,6 +82,10 @@ export default function SettingsPage() {
     setDrzewkoMode,
     betLock,
     setBetLock,
+    matchOrderByRanking,
+    setMatchOrderByRanking,
+    virtualPlayers,
+    setVirtualPlayers,
     pushResults,
     setPushResults,
     pushReminders,
@@ -343,6 +349,42 @@ export default function SettingsPage() {
               przypadkiem go nie zmienić.
             </span>
             <UsageHint count={stats?.bet_lock} />
+          </span>
+        </label>
+
+        <label className="flex cursor-pointer items-start gap-3 px-4 py-4 sm:px-5">
+          <input
+            type="checkbox"
+            className="mt-0.5 h-5 w-5 shrink-0 accent-brand"
+            checked={matchOrderByRanking}
+            onChange={(event) =>
+              toggle('match_order_by_ranking', setMatchOrderByRanking, event.target.checked)
+            }
+          />
+          <span className="leading-snug">
+            <span className="block font-semibold text-ink">Typy w kolejności rankingu</span>
+            <span className="block text-muted">
+              W widoku meczu lista typów uczestników jest ułożona według pozycji w rankingu, a nie
+              alfabetycznie — łatwiej odczytać ranking po meczu.
+            </span>
+            <UsageHint count={stats?.match_order_by_ranking} />
+          </span>
+        </label>
+
+        <label className="flex cursor-pointer items-start gap-3 px-4 py-4 sm:px-5">
+          <input
+            type="checkbox"
+            className="mt-0.5 h-5 w-5 shrink-0 accent-brand"
+            checked={virtualPlayers}
+            onChange={(event) => toggle('virtual_players', setVirtualPlayers, event.target.checked)}
+          />
+          <span className="leading-snug">
+            <span className="block font-semibold text-ink">Wirtualni gracze</span>
+            <span className="block text-muted">
+              W rankingu pojawiają się trzej gracze-strategie do porównania: „Faworyt” (zawsze typuje
+              faworyta), „Underdog” (zawsze niżej notowanego) i „Remis” (zawsze remis).
+            </span>
+            <UsageHint count={stats?.virtual_players} />
           </span>
         </label>
       </section>

--- a/frontend/src/webmcp/tools.ts
+++ b/frontend/src/webmcp/tools.ts
@@ -55,7 +55,8 @@ export function createTools(queryClient: QueryClient): ToolDescriptor[] {
     },
     {
       name: 'get_ranking',
-      description: 'Current leaderboard: position, user, points, and prediction accuracy per player.',
+      description:
+        'Current leaderboard. Returns { entries, perfect_score }: entries lists position, user, points and prediction accuracy per player; perfect_score is the most points obtainable so far (a flawless tipster).',
       inputSchema: NO_INPUT,
       execute: () => authed(() => api.get('/ranking')),
     },

--- a/lib/typerek/ranking/virtual_players.rb
+++ b/lib/typerek/ranking/virtual_players.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Typerek
+  module Ranking
+    # Three synthetic benchmark "players" scored over the finished matches with the
+    # same rule as a real bet (Answer#point): a pick scores the match's odds for it
+    # when that outcome won, otherwise 0. They are an opt-in overlay on the ranking
+    # (the virtual_players setting) that lets a real player see how their tipping
+    # stacks up against three naive strategies:
+    #
+    #   Faworyt  — always backs the more likely side (the lower of win_a / win_b)
+    #   Underdog — always backs the less likely side (the higher of win_a / win_b)
+    #   Remis    — always bets a tie
+    #
+    # Returns plain data ([{ key:, username:, points:, accuracy: }], best first).
+    # Depends only on finished matches' odds and results, so it shares the ranking's
+    # cache fingerprint (see Query.cache_version) and self-invalidates with it.
+    class VirtualPlayers
+      Player = Struct.new(:key, :username, :strategy, keyword_init: true)
+
+      PLAYERS = [
+        Player.new(key: 'favourite', username: 'Faworyt',  strategy: :favourite),
+        Player.new(key: 'underdog',  username: 'Underdog', strategy: :underdog),
+        Player.new(key: 'draw',      username: 'Remis',    strategy: :draw)
+      ].freeze
+
+      def self.call
+        new.call
+      end
+
+      def call
+        matches = Match.finished.to_a
+        PLAYERS.map { |player| score(player, matches) }
+               .sort_by { |row| [-row[:points], row[:username]] }
+      end
+
+      private
+
+      def score(player, matches)
+        points = 0.0
+        accuracy = 0
+        matches.each do |match|
+          result = pick_for(player, match)
+          next if result.nil? || !match.winning_list.include?(result.to_s)
+
+          odds = match.public_send(result)
+          next if odds.nil?
+
+          points += odds.round(2)
+          accuracy += 1
+        end
+        { key: player.key, username: player.username, points: points.round(2), accuracy: accuracy }
+      end
+
+      # The bet this player would place on the match, or nil when it can't be
+      # determined (favourite/underdog need both head-to-head odds to compare).
+      def pick_for(player, match)
+        case player.strategy
+        when :draw then :tie
+        when :favourite then head_to_head(match)&.first
+        when :underdog then head_to_head(match)&.last
+        end
+      end
+
+      # [more_likely, less_likely] outcomes by odds (lower odds = more likely), or
+      # nil when either side's odds are missing. A tie in odds resolves to win_a.
+      def head_to_head(match)
+        return nil if match.win_a.nil? || match.win_b.nil?
+
+        match.win_a <= match.win_b ? %i[win_a win_b] : %i[win_b win_a]
+      end
+    end
+  end
+end

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -64,4 +64,47 @@ RSpec.describe Match, type: :model do
       it { expect(match.winning_list).to eq(%w[tie win_tie_a win_tie_b]) }
     end
   end
+
+  describe '#max_point' do
+    it 'is the best odds among the winning outcomes' do
+      match = described_class.new(result_a: 1, result_b: 0, win_a: 5.0, win_tie_a: 1.5, not_tie: 1.2)
+
+      expect(match.max_point).to eq(5.0)
+    end
+
+    it 'ignores odds of outcomes that did not win' do
+      # A draw, so only tie / win_tie_a / win_tie_b score — win_a's high odds are out.
+      match = described_class.new(result_a: 0, result_b: 0, win_a: 9.9, tie: 3.0, win_tie_a: 1.4, win_tie_b: 1.6)
+
+      expect(match.max_point).to eq(3.0)
+    end
+
+    it 'is zero while the match is unfinished' do
+      match = described_class.new(result_a: nil, result_b: nil, win_a: 5.0)
+
+      expect(match.max_point).to eq(0.0)
+    end
+
+    it 'is zero when none of the winning outcomes has odds set' do
+      match = described_class.new(result_a: 1, result_b: 0, win_a: nil, win_tie_a: nil, not_tie: nil)
+
+      expect(match.max_point).to eq(0.0)
+    end
+  end
+
+  describe '.perfect_score' do
+    it 'sums the best obtainable points across finished matches only' do
+      create(:match, :start_in_past, :winner_a, win_a: 5.0, win_tie_a: 1.5, not_tie: 1.2)
+      create(:match, :start_in_past, :tie, tie: 3.0, win_tie_a: 1.4, win_tie_b: 1.6)
+      create(:match, :start_in_future, :without_results, win_a: 9.9)
+
+      expect(described_class.perfect_score).to eq(8.0)
+    end
+
+    it 'is zero when nothing has finished' do
+      create(:match, :start_in_future, :without_results)
+
+      expect(described_class.perfect_score).to eq(0.0)
+    end
+  end
 end

--- a/spec/requests/api/v1/matches_spec.rb
+++ b/spec/requests/api/v1/matches_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'API V1 Matches', type: :request do
     context 'when the match has started' do
       let(:match) { create(:match, :start_in_past, :without_results) }
 
-      it 'includes participants with their bets' do
+      it 'includes participants with their bets and ranking position' do
         other = create(:user, :active, username: 'zzz')
         create(:answer, match: match, user: other, result: :tie)
 
@@ -38,6 +38,7 @@ RSpec.describe 'API V1 Matches', type: :request do
         expect(json['started']).to be(true)
         entry = json['participants'].find { |p| p['user']['id'] == other.id }
         expect(entry['result']).to eq('tie')
+        expect(entry).to have_key('position')
       end
     end
 

--- a/spec/requests/api/v1/profile_spec.rb
+++ b/spec/requests/api/v1/profile_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe 'API V1 Profile', type: :request do
       expect(json['settings']).to eq(
         'drzewko_mode' => false, 'bet_lock' => false, 'push_enabled' => false,
         'push_results' => true, 'push_reminders' => true, 'theme' => 'light',
-        'favorite_user_ids' => []
+        'favorite_user_ids' => [], 'match_order_by_ranking' => false,
+        'virtual_players' => false
       )
     end
 
@@ -39,12 +40,15 @@ RSpec.describe 'API V1 Profile', type: :request do
       create(:user, :active, settings: { 'drzewko_mode' => true, 'theme' => 'dark' })
       create(:user, :active, settings: { 'theme' => 'auto' })
       create(:user, :active, settings: { 'theme' => 'light' })
+      create(:user, :active, settings: { 'match_order_by_ranking' => true })
+      create(:user, :active, settings: { 'virtual_players' => true })
 
       get '/api/v1/me/settings/stats', headers: auth_headers(user)
 
       expect(response).to have_http_status(:ok)
       expect(json).to eq(
-        'drzewko_mode' => 2, 'bet_lock' => 1, 'push_enabled' => 0, 'theme' => 2
+        'drzewko_mode' => 2, 'bet_lock' => 1, 'push_enabled' => 0,
+        'match_order_by_ranking' => 1, 'virtual_players' => 1, 'theme' => 2
       )
     end
 
@@ -65,9 +69,28 @@ RSpec.describe 'API V1 Profile', type: :request do
       expect(json['settings']).to eq(
         'drzewko_mode' => false, 'bet_lock' => true, 'push_enabled' => false,
         'push_results' => true, 'push_reminders' => true, 'theme' => 'light',
-        'favorite_user_ids' => []
+        'favorite_user_ids' => [], 'match_order_by_ranking' => false,
+        'virtual_players' => false
       )
       expect(user.reload.bet_lock?).to be(true)
+    end
+
+    it 'updates the match-order-by-ranking preference' do
+      patch '/api/v1/me/settings', params: { settings: { match_order_by_ranking: true } },
+            headers: auth_headers(user), as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json['settings']).to include('match_order_by_ranking' => true)
+      expect(user.reload.match_order_by_ranking?).to be(true)
+    end
+
+    it 'updates the virtual-players preference' do
+      patch '/api/v1/me/settings', params: { settings: { virtual_players: true } },
+            headers: auth_headers(user), as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json['settings']).to include('virtual_players' => true)
+      expect(user.reload.virtual_players?).to be(true)
     end
 
     it 'accepts a valid theme preference' do

--- a/spec/requests/api/v1/rankings_spec.rb
+++ b/spec/requests/api/v1/rankings_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'API V1 Ranking', type: :request do
   describe 'GET /api/v1/ranking' do
     it 'returns ordered entries with position, points and accuracy' do
-      match = create(:match, :start_in_past, :winner_a, win_a: 5.0)
+      match = create(:match, :start_in_past, :winner_a, win_a: 5.0, win_tie_a: 1.5, not_tie: 1.2)
       amy = create(:user, :active, username: 'amy')
       create(:user, :active, username: 'bob')
       create(:answer, match: match, user: amy, result: :win_a)
@@ -13,8 +13,42 @@ RSpec.describe 'API V1 Ranking', type: :request do
       get '/api/v1/ranking', headers: auth_headers(amy)
 
       expect(response).to have_http_status(:ok)
-      expect(json.first).to include('position' => 1, 'points' => 5.0, 'accuracy' => 1)
-      expect(json.first['user']).to include('username' => 'amy')
+      expect(json['entries'].first).to include('position' => 1, 'points' => 5.0, 'accuracy' => 1)
+      expect(json['entries'].first['user']).to include('username' => 'amy')
+    end
+
+    it 'reports the perfect score: the best obtainable points across finished matches' do
+      # win_a is the best-paying correct outcome (5.0); the other winning outcomes
+      # (win_tie_a, not_tie) pay less, so the ceiling for this match is 5.0.
+      create(:match, :start_in_past, :winner_a, win_a: 5.0, win_tie_a: 1.5, not_tie: 1.2)
+      amy = create(:user, :active, username: 'amy')
+
+      get '/api/v1/ranking', headers: auth_headers(amy)
+
+      expect(response).to have_http_status(:ok)
+      expect(json['perfect_score']).to eq(5.0)
+    end
+
+    it 'reports a zero perfect score when nothing has finished yet' do
+      create(:match, :start_in_future, :without_results)
+      amy = create(:user, :active, username: 'amy')
+
+      get '/api/v1/ranking', headers: auth_headers(amy)
+
+      expect(json['perfect_score']).to eq(0.0)
+    end
+
+    it 'includes the three virtual benchmark players' do
+      create(:match, :start_in_past, :winner_a, win_a: 1.5, win_b: 4.0)
+      amy = create(:user, :active, username: 'amy')
+
+      get '/api/v1/ranking', headers: auth_headers(amy)
+
+      expect(json['virtual_players'].map { |p| p['key'] })
+        .to contain_exactly('favourite', 'underdog', 'draw')
+      favourite = json['virtual_players'].find { |p| p['key'] == 'favourite' }
+      # win_a (1.5) is the favourite and team A won, so the favourite scores its odds.
+      expect(favourite).to include('username' => 'Faworyt', 'points' => 1.5, 'accuracy' => 1)
     end
   end
 

--- a/spec/typerek/ranking/virtual_players_spec.rb
+++ b/spec/typerek/ranking/virtual_players_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Typerek::Ranking::VirtualPlayers do
+  describe '#call' do
+    it 'scores the favourite, underdog and draw strategies over finished matches' do
+      # Team A won. win_a (1.5) is the favourite, win_b (4.0) the underdog; a draw bet
+      # loses. Only the favourite scores, earning win_a's odds.
+      create(:match, :start_in_past, :winner_a, win_a: 1.5, win_b: 4.0, tie: 3.0)
+
+      result = described_class.call
+
+      by_key = result.index_by { |row| row[:key] }
+      expect(by_key['favourite']).to include(username: 'Faworyt', points: 1.5, accuracy: 1)
+      expect(by_key['underdog']).to include(username: 'Underdog', points: 0.0, accuracy: 0)
+      expect(by_key['draw']).to include(username: 'Remis', points: 0.0, accuracy: 0)
+    end
+
+    it 'backs the higher-odds side as the underdog when it wins' do
+      # Team B won and was the underdog (win_b 4.0 > win_a 1.5), so the underdog scores.
+      create(:match, :start_in_past, :winner_b, win_a: 1.5, win_b: 4.0)
+
+      by_key = described_class.call.index_by { |row| row[:key] }
+
+      expect(by_key['underdog']).to include(points: 4.0, accuracy: 1)
+      expect(by_key['favourite']).to include(points: 0.0, accuracy: 0)
+    end
+
+    it 'scores the draw strategy when the match is a tie' do
+      create(:match, :start_in_past, :tie, tie: 3.0)
+
+      by_key = described_class.call.index_by { |row| row[:key] }
+
+      expect(by_key['draw']).to include(points: 3.0, accuracy: 1)
+    end
+
+    it 'accumulates across matches and returns rows ordered by points desc' do
+      create(:match, :start_in_past, :winner_a, win_a: 2.0, win_b: 5.0)
+      create(:match, :start_in_past, :winner_b, win_a: 1.5, win_b: 6.0)
+
+      result = described_class.call
+
+      # favourite: hits match 1 only (2.0); underdog: hits match 2 only (6.0); draw: 0.
+      expect(result.map { |row| row[:key] }).to eq(%w[underdog favourite draw])
+      expect(result.map { |row| row[:points] }).to eq([6.0, 2.0, 0.0])
+    end
+
+    it 'ignores matches that have not finished' do
+      create(:match, :start_in_future, :without_results, win_a: 1.5, win_b: 4.0)
+
+      result = described_class.call
+
+      expect(result.map { |row| row[:points] }).to all(eq(0.0))
+    end
+  end
+end


### PR DESCRIPTION
…yers

Four ranking/match features:

- Ranking by hits ("trafienia"): a Sortuj toggle in the Tabela tab re-ranks client-side (new lib/ranking.ts), URL-backed (?sort=hits). The points-only chrome (movement arrows, prize zone) is hidden in that order.

- Perfect score: Match#max_point / Match.perfect_score expose the season's point ceiling. /ranking now returns { entries, perfect_score, virtual_players }. Each player's points show a (% z N pkt) share, folded into the "Twoja pozycja" banner.

- Typy in ranking order (opt-in match_order_by_ranking): the participant payload carries each player's ranking position; the match view orders by it when on.

- Virtual players (opt-in virtual_players): Typerek::Ranking::VirtualPlayers scores Faworyt / Underdog / Remis over finished matches; when on they are interleaved into the ranking and shift real positions, rendered distinctly.

Both new settings appear on the Ustawienia screen with the usual usage hint.