### PR TITLE
Show each player's points in the ranking-ordered match view

### DIFF
--- a/app/serializers/api/v1/match_detail_serializer.rb
+++ b/app/serializers/api/v1/match_detail_serializer.rb
@@ -13,17 +13,20 @@ module Api
 
       def self.participants(match)
         answers = match.answers.group_by(&:user_id).transform_values(&:first)
-        # Each participant's current ranking position, so the client can optionally
-        # order the list by standings (the match_order_by_ranking setting). Read from
-        # the cached standings map — every active user has an entry. Default order
-        # stays alphabetical; the client re-sorts when the setting is on.
+        # Each participant's current ranking position and points, so the client can
+        # optionally order the list by standings (the match_order_by_ranking setting)
+        # and show how many points each player is on — making it easy to reason about
+        # how a correct bet would move them. Read from the cached standings map —
+        # every active user has an entry. Default order stays alphabetical; the
+        # client re-sorts when the setting is on.
         standings = Typerek::Ranking::Query.standings
         User.active.order(:username).map do |user|
           answer = answers[user.id]
           {
             user: { id: user.id, username: user.username },
             result: answer&.result,
-            position: standings.dig(user.id, :position)
+            position: standings.dig(user.id, :position),
+            points: standings.dig(user.id, :points)
           }
         end
       end

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -88,9 +88,11 @@ export interface Match {
 export interface Participant {
   user: { id: number; username: string }
   result: BetType | null
-  // The participant's current ranking position, used to optionally order the list
-  // by standings (the match_order_by_ranking setting). null if not ranked.
+  // The participant's current ranking position and points, used to optionally order
+  // the list by standings (the match_order_by_ranking setting) and show how a
+  // correct bet would move them. null if not ranked.
   position: number | null
+  points: number | null
 }
 
 export interface MatchDetail extends Match {

--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -9,7 +9,7 @@ import BetGrid from '@/components/BetGrid'
 import LockToggle from '@/components/LockToggle'
 import BetDistributionChart from '@/components/BetDistributionChart'
 import { BET_TYPES, betPillClass, winningBets } from '@/lib/bets'
-import { formatShort, formattedOdds, formattedScore } from '@/lib/format'
+import { formatShort, formattedOdds, formattedScore, pointsDisplay } from '@/lib/format'
 import { useDocumentTitle } from '@/lib/useDocumentTitle'
 import { useSettings } from '@/lib/settings'
 
@@ -150,7 +150,7 @@ export default function MatchPage() {
                   fav ? 'bg-amber-100/80 dark:bg-amber-500/10' : ''
                 }`}
               >
-                <div className={`flex items-center gap-1.5 ${fav ? 'font-semibold' : 'font-medium'}`}>
+                <div className={`flex min-w-0 items-center gap-1.5 sm:flex-1 ${fav ? 'font-semibold' : 'font-medium'}`}>
                   {/* When ordering by ranking, lead each row with its position so the
                       standings read off at a glance. */}
                   {matchOrderByRanking && (
@@ -180,14 +180,23 @@ export default function MatchPage() {
                       <i className={`${fav ? 'fas' : 'far'} fa-star`} aria-hidden="true" />
                     </button>
                   )}
-                  <Link to={`/users/${participant.user.id}`} className="text-ink hover:text-brand">
+                  <Link to={`/users/${participant.user.id}`} className="truncate text-ink hover:text-brand">
                     {participant.user.username}
                   </Link>
+                  {/* In ranking order, show the player's current points right-aligned in
+                      a fixed column (ml-auto against the flex-1 name), so they line up
+                      down the list and it's easy to work out how a correct bet (its odds
+                      are in the pill) moves them. */}
+                  {matchOrderByRanking && participant.points != null && (
+                    <span className="ml-auto shrink-0 pl-2 text-xs font-normal text-muted tabular-nums">
+                      {pointsDisplay(participant.points)} pkt
+                    </span>
+                  )}
                 </div>
                 {participant.result == null ? (
-                  <span className="text-sm text-muted sm:ml-auto">Brak typu</span>
+                  <span className="text-sm text-muted sm:w-[340px] sm:shrink-0 sm:text-right">Brak typu</span>
                 ) : (
-                  <div className="bet-grid sm:ml-auto sm:w-[340px]">
+                  <div className="bet-grid sm:w-[340px] sm:shrink-0">
                     {BET_TYPES.map(([result, label]) => {
                       const chosen = participant.result === result
                       const isScored = scored?.has(result) ?? false

--- a/spec/requests/api/v1/matches_spec.rb
+++ b/spec/requests/api/v1/matches_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'API V1 Matches', type: :request do
     context 'when the match has started' do
       let(:match) { create(:match, :start_in_past, :without_results) }
 
-      it 'includes participants with their bets and ranking position' do
+      it 'includes participants with their bets and ranking standing' do
         other = create(:user, :active, username: 'zzz')
         create(:answer, match: match, user: other, result: :tie)
 
@@ -39,6 +39,7 @@ RSpec.describe 'API V1 Matches', type: :request do
         entry = json['participants'].find { |p| p['user']['id'] == other.id }
         expect(entry['result']).to eq('tie')
         expect(entry).to have_key('position')
+        expect(entry).to have_key('points')
       end
     end
 


### PR DESCRIPTION
When a match's participant list is sorted by ranking, each player now shows their current points in a right-aligned column next to their name. Combined with the odds in their pick's pill, it's easy to see how a correct bet would move them. The participant payload carries `points` from the cached standings; the name column is flex-1 so the points line up regardless of nick length.