### PR TITLE
Group ranking filters, move virtual toggle there, add strategy profiles

### DIFF
--- a/app/controllers/api/v1/rankings_controller.rb
+++ b/app/controllers/api/v1/rankings_controller.rb
@@ -24,6 +24,16 @@ module Api
         render json: json
       end
 
+      # One virtual strategy's profile: its totals plus its pick on every started
+      # match, so the client can show how the strategy's hits look. 404 for an
+      # unknown key. Not cached — a per-strategy detail view, hit infrequently.
+      def virtual_player
+        profile = Typerek::Ranking::VirtualPlayers.profile(params[:key])
+        return head :not_found unless profile
+
+        render json: VirtualPlayerProfileSerializer.call(profile)
+      end
+
       def history
         history = Typerek::Ranking::History
         json = Rails.cache.fetch(

--- a/app/serializers/api/v1/virtual_player_profile_serializer.rb
+++ b/app/serializers/api/v1/virtual_player_profile_serializer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # The `VirtualPlayerProfile` schema — a virtual strategy's totals plus its pick
+    # on every started match (rendered like a real player's profile, so the client
+    # can show the strategy's hits and misses). Mirrors UserProfileSerializer.
+    class VirtualPlayerProfileSerializer
+      def self.call(profile)
+        {
+          player: {
+            key: profile[:key],
+            username: profile[:username],
+            points: profile[:points],
+            accuracy: profile[:accuracy]
+          },
+          started_matches: profile[:matches].map do |entry|
+            MatchSerializer.call(entry[:match]).merge(answer: entry[:pick]&.to_s)
+          end
+        }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
 
       get 'ranking', to: 'rankings#show'
       get 'ranking/history', to: 'rankings#history'
+      get 'ranking/virtual_players/:key', to: 'rankings#virtual_player'
 
       get 'bets', to: 'bets#index'
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import MatchesPage from '@/pages/MatchesPage'
 import MatchPage from '@/pages/MatchPage'
 import MatchEditPage from '@/pages/MatchEditPage'
 import RankingPage from '@/pages/RankingPage'
+import VirtualPlayerPage from '@/pages/VirtualPlayerPage'
 import SettingsPage from '@/pages/SettingsPage'
 import AdminPushPage from '@/pages/AdminPushPage'
 import UsersPage from '@/pages/UsersPage'
@@ -34,6 +35,7 @@ export default function App() {
           <Route path="/matches/:id" element={<MatchPage />} />
           <Route path="/matches/:id/edit" element={<MatchEditPage />} />
           <Route path="/ranking" element={<RankingPage />} />
+          <Route path="/ranking/virtual/:key" element={<VirtualPlayerPage />} />
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="/admin/push" element={<AdminPushPage />} />
           <Route path="/users" element={<UsersPage />} />

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -14,6 +14,7 @@ import type {
   RankingHistory,
   User,
   UserProfile,
+  VirtualPlayerProfile,
 } from './types'
 
 export const queryKeys = {
@@ -82,6 +83,13 @@ export function useUserProfile(id: number | string) {
   return useQuery({
     queryKey: queryKeys.user(id),
     queryFn: () => api.get<UserProfile>(`/users/${id}`),
+  })
+}
+
+export function useVirtualPlayer(key: string) {
+  return useQuery({
+    queryKey: ['ranking', 'virtual', key],
+    queryFn: () => api.get<VirtualPlayerProfile>(`/ranking/virtual_players/${key}`),
   })
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -147,6 +147,13 @@ export interface UserProfile {
   started_matches: UserProfileMatch[]
 }
 
+// A virtual benchmark strategy's profile: its totals plus its pick on every
+// started match, so its hits and misses can be shown like a real player's.
+export interface VirtualPlayerProfile {
+  player: { key: string; username: string; points: number; accuracy: number }
+  started_matches: UserProfileMatch[]
+}
+
 export interface InvitationInfo {
   username: string
 }

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -88,7 +88,7 @@ function parseView(param: string | null): View {
 export default function RankingPage() {
   const { data, isLoading, isError } = useRanking()
   const { user } = useAuth()
-  const { drzewkoMode, favoriteUserIds, toggleFavorite, virtualPlayers } = useSettings()
+  const { drzewkoMode, favoriteUserIds, toggleFavorite, virtualPlayers, setVirtualPlayers } = useSettings()
   const meRowRef = useRef<HTMLLIElement>(null)
   const [query, setQuery] = useState('')
   const [favoritesOnly, setFavoritesOnly] = useState(false)
@@ -172,7 +172,12 @@ export default function RankingPage() {
   const filtering = folded !== '' || favoritesOnly
   const visible = ranked.filter(
     (entry) =>
-      (!favoritesOnly || favorites.has(entry.user.id) || entry.user.id === user?.id) &&
+      // Favourites-only keeps your own row and the virtual benchmarks (they are an
+      // opt-in overlay, not players you'd filter away), plus your starred users.
+      (!favoritesOnly ||
+        favorites.has(entry.user.id) ||
+        entry.user.id === user?.id ||
+        entry.virtualKey != null) &&
       (folded === '' || fold(entry.user.username).includes(folded)),
   )
 
@@ -223,8 +228,7 @@ export default function RankingPage() {
   return (
     <>
       <h1 className="mb-4 flex items-center gap-2">
-        <i className="fas fa-trophy text-brand" aria-hidden="true" /> Ranking{' '}
-        <span className="badge-count">{entries.length}</span>
+        <i className="fas fa-trophy text-brand" aria-hidden="true" /> Ranking
       </h1>
 
       <div className="mb-5 flex border-b border-line">
@@ -253,29 +257,6 @@ export default function RankingPage() {
 
       {view === 'table' ? (
         <div className="mx-auto max-w-xl">
-          <div className="mb-4 flex items-center gap-2">
-            <span className="text-sm font-medium text-muted">Sortuj:</span>
-            <div className="inline-flex rounded-full bg-surface p-0.5">
-              {(
-                [
-                  ['points', 'Punkty'],
-                  ['hits', 'Trafienia'],
-                ] as const
-              ).map(([value, label]) => (
-                <button
-                  key={value}
-                  type="button"
-                  onClick={() => selectSort(value)}
-                  aria-pressed={sort === value}
-                  className={`rounded-full px-3 py-1.5 text-sm font-medium transition-colors ${
-                    sort === value ? 'bg-brand text-white shadow-sm' : 'text-muted hover:text-ink'
-                  }`}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
-          </div>
           {meEntry && (
             <div className="card card-body mb-4 flex items-center justify-between gap-3 border border-brand bg-brand-tint">
               <span className="leading-tight">
@@ -307,49 +288,92 @@ export default function RankingPage() {
               </button>
             </div>
           )}
-          <div className="relative mb-3">
-            <i
-              className="fas fa-magnifying-glass pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted"
-              aria-hidden="true"
-            />
-            <input
-              type="text"
-              inputMode="search"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Szukaj zawodnika…"
-              aria-label="Szukaj zawodnika"
-              autoCapitalize="none"
-              autoCorrect="off"
-              className="field pl-9 pr-9"
-            />
-            {query !== '' && (
+          {/* Filters grouped in one box so they read as a set of view options
+              rather than loose controls blending into the page. */}
+          <div className="card card-body mb-4 space-y-3">
+            <div className="relative">
+              <i
+                className="fas fa-magnifying-glass pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted"
+                aria-hidden="true"
+              />
+              <input
+                type="text"
+                inputMode="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Szukaj zawodnika…"
+                aria-label="Szukaj zawodnika"
+                autoCapitalize="none"
+                autoCorrect="off"
+                className="field pl-9 pr-9"
+              />
+              {query !== '' && (
+                <button
+                  type="button"
+                  onClick={() => setQuery('')}
+                  aria-label="Wyczyść wyszukiwanie"
+                  title="Wyczyść"
+                  className="absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-muted transition-colors hover:bg-black/5 hover:text-ink dark:hover:bg-white/10"
+                >
+                  <i className="fas fa-xmark" aria-hidden="true" />
+                </button>
+              )}
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="inline-flex items-center gap-2">
+                <span className="text-sm font-medium text-muted">Sortuj:</span>
+                <div className="inline-flex rounded-full bg-surface p-0.5">
+                  {(
+                    [
+                      ['points', 'Punkty'],
+                      ['hits', 'Trafienia'],
+                    ] as const
+                  ).map(([value, label]) => (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() => selectSort(value)}
+                      aria-pressed={sort === value}
+                      className={`rounded-full px-3 py-1.5 text-sm font-medium transition-colors ${
+                        sort === value ? 'bg-brand text-white shadow-sm' : 'text-muted hover:text-ink'
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              {(hasFavorites || favoritesOnly) && (
+                <button
+                  type="button"
+                  onClick={() => setFavoritesOnly((value) => !value)}
+                  aria-pressed={favoritesOnly}
+                  className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
+                    favoritesOnly
+                      ? 'border-amber-400 bg-amber-100/80 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300'
+                      : 'border-line text-muted hover:bg-black/5 dark:hover:bg-white/10'
+                  }`}
+                >
+                  <i className={`${favoritesOnly ? 'fas text-yellow-400' : 'far'} fa-star`} aria-hidden="true" />
+                  Tylko ulubieni
+                </button>
+              )}
               <button
                 type="button"
-                onClick={() => setQuery('')}
-                aria-label="Wyczyść wyszukiwanie"
-                title="Wyczyść"
-                className="absolute right-2 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-muted transition-colors hover:bg-black/5 hover:text-ink dark:hover:bg-white/10"
+                onClick={() => void setVirtualPlayers(!virtualPlayers)}
+                aria-pressed={virtualPlayers}
+                title="Pokaż w rankingu strategie-benchmarki: Faworyt, Underdog, Remis"
+                className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
+                  virtualPlayers
+                    ? 'border-brand bg-brand-tint text-brand'
+                    : 'border-line text-muted hover:bg-black/5 dark:hover:bg-white/10'
+                }`}
               >
-                <i className="fas fa-xmark" aria-hidden="true" />
+                <i className="fas fa-robot" aria-hidden="true" />
+                Wirtualni gracze
               </button>
-            )}
+            </div>
           </div>
-          {(hasFavorites || favoritesOnly) && (
-            <button
-              type="button"
-              onClick={() => setFavoritesOnly((value) => !value)}
-              aria-pressed={favoritesOnly}
-              className={`mb-3 inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
-                favoritesOnly
-                  ? 'border-amber-400 bg-amber-100/80 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300'
-                  : 'border-line text-muted hover:bg-black/5 dark:hover:bg-white/10'
-              }`}
-            >
-              <i className={`${favoritesOnly ? 'fas text-yellow-400' : 'far'} fa-star`} aria-hidden="true" />
-              Tylko ulubieni
-            </button>
-          )}
           {visible.length === 0 ? (
             <div className="card card-body text-center text-muted">
               {query.trim()
@@ -398,12 +422,15 @@ export default function RankingPage() {
                     {augmented ? null : <Movement entry={entry} />}
                     <span className={`flex-1 truncate ${fav ? 'font-semibold' : 'font-medium'}`}>
                       {virtual ? (
-                        <span className="inline-flex items-center gap-1.5 text-muted">
+                        <Link
+                          to={`/ranking/virtual/${entry.virtualKey}`}
+                          className="inline-flex items-center gap-1.5 text-muted hover:text-brand"
+                        >
                           <span className="italic">{entry.user.username}</span>
                           <span className="rounded bg-surface px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted">
                             wirtualny
                           </span>
-                        </span>
+                        </Link>
                       ) : (
                         <Link to={`/users/${entry.user.id}`} className="text-ink hover:text-brand">
                           {entry.user.username}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -24,7 +24,6 @@ type SettingsStats = {
   bet_lock: number
   push_enabled: number
   match_order_by_ranking: number
-  virtual_players: number
   // How many users have dark mode on (theme 'dark' or 'auto').
   theme: number
 }
@@ -84,8 +83,6 @@ export default function SettingsPage() {
     setBetLock,
     matchOrderByRanking,
     setMatchOrderByRanking,
-    virtualPlayers,
-    setVirtualPlayers,
     pushResults,
     setPushResults,
     pushReminders,
@@ -368,23 +365,6 @@ export default function SettingsPage() {
               alfabetycznie — łatwiej odczytać ranking po meczu.
             </span>
             <UsageHint count={stats?.match_order_by_ranking} />
-          </span>
-        </label>
-
-        <label className="flex cursor-pointer items-start gap-3 px-4 py-4 sm:px-5">
-          <input
-            type="checkbox"
-            className="mt-0.5 h-5 w-5 shrink-0 accent-brand"
-            checked={virtualPlayers}
-            onChange={(event) => toggle('virtual_players', setVirtualPlayers, event.target.checked)}
-          />
-          <span className="leading-snug">
-            <span className="block font-semibold text-ink">Wirtualni gracze</span>
-            <span className="block text-muted">
-              W rankingu pojawiają się trzej gracze-strategie do porównania: „Faworyt” (zawsze typuje
-              faworyta), „Underdog” (zawsze niżej notowanego) i „Remis” (zawsze remis).
-            </span>
-            <UsageHint count={stats?.virtual_players} />
           </span>
         </label>
       </section>

--- a/frontend/src/pages/VirtualPlayerPage.tsx
+++ b/frontend/src/pages/VirtualPlayerPage.tsx
@@ -1,0 +1,79 @@
+import { Link, useParams } from 'react-router-dom'
+import { useVirtualPlayer } from '@/api/hooks'
+import { ErrorBox, Loading } from '@/components/Status'
+import MatchLine from '@/components/MatchLine'
+import BetGrid from '@/components/BetGrid'
+import { formatDateLong, groupByDay, pointsDisplay } from '@/lib/format'
+import { useDocumentTitle } from '@/lib/useDocumentTitle'
+
+// How each strategy picks, shown under its name so the profile explains itself.
+const STRATEGY_HINT: Record<string, string> = {
+  favourite: 'Zawsze typuje faworyta — niższy z kursów 1 / 2 (najbardziej prawdopodobny wynik).',
+  underdog: 'Zawsze typuje niżej notowanego — wyższy z kursów 1 / 2.',
+  draw: 'Zawsze typuje remis.',
+}
+
+// A virtual benchmark strategy's "profile": its picks on started matches, so its
+// hits and misses read off exactly like a real participant's (UserProfilePage).
+export default function VirtualPlayerPage() {
+  const { key = '' } = useParams()
+  const { data, isLoading, isError } = useVirtualPlayer(key)
+
+  useDocumentTitle(data ? `Strategia: ${data.player.username}` : undefined)
+
+  if (isLoading) return <Loading />
+  if (isError || !data) return <ErrorBox />
+
+  return (
+    <>
+      <Link to="/ranking" className="mb-4 inline-flex items-center gap-1 text-sm text-muted hover:text-brand">
+        <i className="fas fa-angle-left" aria-hidden="true" /> Ranking
+      </Link>
+
+      <div className="mb-5">
+        <h1 className="flex items-center gap-2">
+          <i className="fas fa-robot text-brand" aria-hidden="true" /> {data.player.username}
+          <span className="rounded bg-surface px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted">
+            wirtualny
+          </span>
+        </h1>
+        {STRATEGY_HINT[data.player.key] && (
+          <p className="mt-1 text-muted">{STRATEGY_HINT[data.player.key]}</p>
+        )}
+        <p className="mt-1 text-muted">
+          Liczba trafień: <span className="font-semibold text-ink">{data.player.accuracy}</span> ·{' '}
+          <span className="font-semibold text-ink tabular-nums">{pointsDisplay(data.player.points)}</span> pkt
+        </p>
+      </div>
+
+      {data.started_matches.length === 0 ? (
+        <div className="card card-body text-center text-muted">Brak rozegranych meczów</div>
+      ) : (
+        <div className="space-y-4">
+          {groupByDay(data.started_matches).map((group) => (
+            <section key={group.start} className="card overflow-hidden">
+              <div className="card-header">
+                <h3 className="text-sm font-bold text-muted">{formatDateLong(group.start)}</h3>
+              </div>
+              <div className="divide-y divide-line/60">
+                {group.items.map((match) => (
+                  <div
+                    key={match.id}
+                    className={`flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-5${
+                      match.started && !match.finished ? ' bg-highlight/70' : ''
+                    }`}
+                  >
+                    <MatchLine match={match} />
+                    <div className="sm:w-[340px]">
+                      <BetGrid match={match} myAnswer={match.answer} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </>
+  )
+}

--- a/lib/typerek/ranking/virtual_players.rb
+++ b/lib/typerek/ranking/virtual_players.rb
@@ -24,14 +24,35 @@ module Typerek
         Player.new(key: 'draw',      username: 'Remis',    strategy: :draw)
       ].freeze
 
+      # Valid strategy keys, for routing/validation of the per-strategy profile.
+      KEYS = PLAYERS.map(&:key).freeze
+
       def self.call
         new.call
+      end
+
+      # Per-match breakdown for one strategy, or nil for an unknown key: the same
+      # totals shown in the ranking plus, for every started match, the pick the
+      # strategy would make — so the client can render that strategy's hits/misses.
+      def self.profile(key)
+        player = PLAYERS.find { |entry| entry.key == key }
+        player && new.profile(player)
       end
 
       def call
         matches = Match.finished.to_a
         PLAYERS.map { |player| score(player, matches) }
                .sort_by { |row| [-row[:points], row[:username]] }
+      end
+
+      def profile(player)
+        # Totals stay scored over finished matches (matching the ranking); the
+        # per-match list mirrors a real player's profile, which shows started matches.
+        score(player, Match.finished.to_a).merge(
+          matches: Match.started.includes(:answers).map do |match|
+            { match: match, pick: pick_for(player, match) }
+          end
+        )
       end
 
       private

--- a/spec/requests/api/v1/rankings_spec.rb
+++ b/spec/requests/api/v1/rankings_spec.rb
@@ -52,6 +52,28 @@ RSpec.describe 'API V1 Ranking', type: :request do
     end
   end
 
+  describe 'GET /api/v1/ranking/virtual_players/:key' do
+    it 'returns the strategy totals and its pick on each started match' do
+      create(:match, :start_in_past, :winner_a, win_a: 1.5, win_b: 4.0)
+      amy = create(:user, :active, username: 'amy')
+
+      get '/api/v1/ranking/virtual_players/favourite', headers: auth_headers(amy)
+
+      expect(response).to have_http_status(:ok)
+      expect(json['player']).to include('key' => 'favourite', 'username' => 'Faworyt', 'accuracy' => 1)
+      expect(json['started_matches'].length).to eq(1)
+      expect(json['started_matches'].first['answer']).to eq('win_a')
+    end
+
+    it 'returns 404 for an unknown strategy key' do
+      amy = create(:user, :active, username: 'amy')
+
+      get '/api/v1/ranking/virtual_players/nope', headers: auth_headers(amy)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
   describe 'GET /api/v1/ranking/history' do
     it 'returns matches and aligned series arrays' do
       match1 = create(:match, :winner_a, win_a: 3.0, start: 2.days.ago)

--- a/spec/typerek/ranking/virtual_players_spec.rb
+++ b/spec/typerek/ranking/virtual_players_spec.rb
@@ -54,4 +54,20 @@ RSpec.describe Typerek::Ranking::VirtualPlayers do
       expect(result.map { |row| row[:points] }).to all(eq(0.0))
     end
   end
+
+  describe '.profile' do
+    it 'returns the strategy totals plus its pick on every started match' do
+      create(:match, :start_in_past, :winner_a, win_a: 1.5, win_b: 4.0)
+
+      profile = described_class.profile('favourite')
+
+      expect(profile).to include(key: 'favourite', username: 'Faworyt', points: 1.5, accuracy: 1)
+      expect(profile[:matches].length).to eq(1)
+      expect(profile[:matches].first[:pick]).to eq(:win_a)
+    end
+
+    it 'returns nil for an unknown strategy key' do
+      expect(described_class.profile('nope')).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
- Ranking filters (search, sort, "tylko ulubieni") are grouped in one box so they read as a set of view options instead of loose controls blending into the page background.
- The "Wirtualni gracze" toggle moves out of Settings into that box, so the benchmark players can be flipped on/off right where they appear.
- Clicking a virtual player opens its strategy profile (/ranking/virtual/:key, GET /api/v1/ranking/virtual_players/:key): the strategy's pick on every started match, rendered like a real player's profile so its hits and misses read off directly.
- The player count next to the "Ranking" header is dropped — "Twoja pozycja" already shows the field size.