### PR TITLE
Add per-team match history reachable from any team name

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import HomePage from '@/pages/HomePage'
 import MatchesPage from '@/pages/MatchesPage'
 import MatchPage from '@/pages/MatchPage'
 import MatchEditPage from '@/pages/MatchEditPage'
+import TeamPage from '@/pages/TeamPage'
 import RankingPage from '@/pages/RankingPage'
 import VirtualPlayerPage from '@/pages/VirtualPlayerPage'
 import SettingsPage from '@/pages/SettingsPage'
@@ -34,6 +35,7 @@ export default function App() {
           <Route path="/matches" element={<MatchesPage />} />
           <Route path="/matches/:id" element={<MatchPage />} />
           <Route path="/matches/:id/edit" element={<MatchEditPage />} />
+          <Route path="/teams/:name" element={<TeamPage />} />
           <Route path="/ranking" element={<RankingPage />} />
           <Route path="/ranking/virtual/:key" element={<VirtualPlayerPage />} />
           <Route path="/settings" element={<SettingsPage />} />

--- a/frontend/src/components/MatchLine.tsx
+++ b/frontend/src/components/MatchLine.tsx
@@ -43,12 +43,23 @@ function Countdown({ start }: { start: string }) {
 // with the score centered. Mirrors matches/_match_line.html.erb.
 // `started` can be passed from a parent that already holds the value to avoid a
 // duplicate hook call; when omitted, the component computes it internally.
+//
+// The row opens the match, but each team name links to that team's history
+// instead. Anchors can't nest, so the match link is an overlay (`absolute
+// inset-0`) painted beneath the raised team-name links rather than wrapping them:
+// clicking a name hits the name's link, clicking anywhere else falls through to
+// the match.
 export default function MatchLine({ match, started }: { match: Match; started?: boolean }) {
   const internal = useLocalStarted(match)
   const localStarted = started ?? internal
   const live = localStarted && !match.finished
   return (
-    <Link to={`/matches/${match.id}`} className="group flex items-center gap-2 sm:flex-1 sm:gap-3">
+    <div className="group relative flex items-center gap-2 sm:flex-1 sm:gap-3">
+      <Link
+        to={`/matches/${match.id}`}
+        aria-label={`${match.team_a} – ${match.team_b}`}
+        className="absolute inset-0"
+      />
       <span className="flex w-14 shrink-0 flex-col gap-0.5">
         <span className="text-sm font-semibold tabular-nums text-muted">{formatTime(match.start)}</span>
         {live && (
@@ -60,18 +71,28 @@ export default function MatchLine({ match, started }: { match: Match; started?: 
         {!localStarted && <Countdown start={match.start} />}
       </span>
       <span className="flex flex-1 items-center justify-center gap-2 sm:gap-3">
-        <span className="flex flex-1 items-center justify-end gap-2 font-semibold text-ink group-hover:text-brand">
-          {match.team_a}
+        <span className="flex flex-1 items-center justify-end gap-2 font-semibold text-ink">
+          <Link
+            to={`/teams/${encodeURIComponent(match.team_a)}`}
+            className="relative z-10 group-hover:text-brand hover:text-brand hover:underline"
+          >
+            {match.team_a}
+          </Link>
           <Flag team={match.team_a} className="h-3.5 w-5 shrink-0 rounded-sm" />
         </span>
         <span className="shrink-0 rounded-md bg-surface px-2 py-1 text-sm font-bold tabular-nums text-ink">
           {formattedScore(match.result_a, match.result_b)}
         </span>
-        <span className="flex flex-1 items-center gap-2 font-semibold text-ink group-hover:text-brand">
+        <span className="flex flex-1 items-center gap-2 font-semibold text-ink">
           <Flag team={match.team_b} className="h-3.5 w-5 shrink-0 rounded-sm" />
-          {match.team_b}
+          <Link
+            to={`/teams/${encodeURIComponent(match.team_b)}`}
+            className="relative z-10 group-hover:text-brand hover:text-brand hover:underline"
+          >
+            {match.team_b}
+          </Link>
         </span>
       </span>
-    </Link>
+    </div>
   )
 }

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -48,6 +48,11 @@ export function toDateTimeLocalValue(iso: string): string {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
 }
 
+// Short "day month" label, e.g. "12 cze" — used in the team match history list.
+export function formatDayMonth(iso: string): string {
+  return new Date(iso).toLocaleDateString(LOCALE, { day: 'numeric', month: 'short' })
+}
+
 export function formatShort(iso: string): string {
   return new Date(iso).toLocaleString(LOCALE, {
     day: 'numeric',

--- a/frontend/src/lib/teams.test.ts
+++ b/frontend/src/lib/teams.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import type { Match, MatchList } from '@/api/types'
+import { matchCountLabel, teamOutcome, teamRecord, teamSchedule } from './teams'
+
+// Minimal match factory — only the fields the team helpers read matter.
+function match(overrides: Partial<Match>): Match {
+  return {
+    id: 1,
+    team_a: 'Polska',
+    team_b: 'Niemcy',
+    start: '2026-06-12T18:00:00Z',
+    started: true,
+    finished: false,
+    result_a: null,
+    result_b: null,
+    odds: { win_a: null, tie: null, win_b: null, win_tie_a: null, win_tie_b: null, not_tie: null },
+    my_answer: null,
+    my_locked: false,
+    ...overrides,
+  }
+}
+
+describe('teamOutcome', () => {
+  it('reads the result from the chosen team’s side', () => {
+    const m = match({ team_a: 'Polska', team_b: 'Niemcy', result_a: 2, result_b: 0, finished: true })
+    expect(teamOutcome(m, 'Polska')).toBe('win')
+    expect(teamOutcome(m, 'Niemcy')).toBe('loss')
+  })
+
+  it('treats equal scores as a draw', () => {
+    const m = match({ result_a: 1, result_b: 1, finished: true })
+    expect(teamOutcome(m, 'Polska')).toBe('draw')
+    expect(teamOutcome(m, 'Niemcy')).toBe('draw')
+  })
+
+  it('returns null when unfinished or the team did not play', () => {
+    expect(teamOutcome(match({ result_a: null, result_b: null }), 'Polska')).toBeNull()
+    expect(teamOutcome(match({ result_a: 2, result_b: 0, finished: true }), 'Brazylia')).toBeNull()
+  })
+})
+
+describe('teamRecord', () => {
+  it('tallies wins, draws and losses for the team', () => {
+    const matches = [
+      match({ id: 1, team_a: 'Polska', team_b: 'A', result_a: 2, result_b: 0, finished: true }),
+      match({ id: 2, team_a: 'B', team_b: 'Polska', result_a: 1, result_b: 1, finished: true }),
+      match({ id: 3, team_a: 'Polska', team_b: 'C', result_a: 0, result_b: 3, finished: true }),
+      match({ id: 4, team_a: 'D', team_b: 'E', result_a: 1, result_b: 0, finished: true }),
+    ]
+    expect(teamRecord(matches, 'Polska')).toEqual({ played: 3, wins: 1, draws: 1, losses: 1 })
+  })
+})
+
+describe('teamSchedule', () => {
+  it('keeps only the team’s matches, split and ordered oldest-first', () => {
+    const list: MatchList = {
+      not_finished: [
+        match({ id: 10, team_a: 'Polska', team_b: 'X', start: '2026-06-25T18:00:00Z' }),
+        match({ id: 11, team_a: 'Y', team_b: 'Z', start: '2026-06-24T18:00:00Z' }),
+      ],
+      finished: [
+        match({ id: 20, team_a: 'W', team_b: 'Polska', start: '2026-06-16T18:00:00Z', result_a: 0, result_b: 1, finished: true }),
+        match({ id: 21, team_a: 'Polska', team_b: 'V', start: '2026-06-12T18:00:00Z', result_a: 2, result_b: 0, finished: true }),
+      ],
+    }
+    const schedule = teamSchedule(list, 'Polska')
+    expect(schedule.upcoming.map((m) => m.id)).toEqual([10])
+    expect(schedule.finished.map((m) => m.id)).toEqual([21, 20])
+  })
+})
+
+describe('matchCountLabel', () => {
+  it('uses the right Polish plural form', () => {
+    expect(matchCountLabel(1)).toBe('1 mecz')
+    expect(matchCountLabel(3)).toBe('3 mecze')
+    expect(matchCountLabel(5)).toBe('5 meczów')
+    expect(matchCountLabel(12)).toBe('12 meczów')
+    expect(matchCountLabel(22)).toBe('22 mecze')
+  })
+})

--- a/frontend/src/lib/teams.ts
+++ b/frontend/src/lib/teams.ts
@@ -1,0 +1,64 @@
+import type { Match, MatchList } from '@/api/types'
+
+// A finished match's result from one team's point of view. null while the match
+// has no result yet, or when the team didn't play in it.
+export type TeamOutcome = 'win' | 'draw' | 'loss'
+
+export function teamOutcome(match: Match, team: string): TeamOutcome | null {
+  if (match.result_a == null || match.result_b == null) return null
+  if (match.team_a !== team && match.team_b !== team) return null
+  const isA = match.team_a === team
+  const own = isA ? match.result_a : match.result_b
+  const opp = isA ? match.result_b : match.result_a
+  if (own > opp) return 'win'
+  if (own < opp) return 'loss'
+  return 'draw'
+}
+
+export interface TeamRecord {
+  played: number
+  wins: number
+  draws: number
+  losses: number
+}
+
+// The team's win/draw/loss tally over the finished matches it played in.
+export function teamRecord(matches: Match[], team: string): TeamRecord {
+  const record: TeamRecord = { played: 0, wins: 0, draws: 0, losses: 0 }
+  for (const match of matches) {
+    const outcome = teamOutcome(match, team)
+    if (!outcome) continue
+    record.played += 1
+    if (outcome === 'win') record.wins += 1
+    else if (outcome === 'draw') record.draws += 1
+    else record.losses += 1
+  }
+  return record
+}
+
+export interface TeamSchedule {
+  finished: Match[]
+  upcoming: Match[]
+}
+
+// Pull every match a team plays in out of the full match list, split into
+// finished and upcoming and ordered chronologically (oldest first) so the two
+// sections read as one timeline. The list already carries every match (see
+// useMatches), so no extra request is needed.
+export function teamSchedule(list: MatchList, team: string): TeamSchedule {
+  const involves = (match: Match) => match.team_a === team || match.team_b === team
+  const byStartAsc = (a: Match, b: Match) => new Date(a.start).getTime() - new Date(b.start).getTime()
+  return {
+    finished: list.finished.filter(involves).sort(byStartAsc),
+    upcoming: list.not_finished.filter(involves).sort(byStartAsc),
+  }
+}
+
+// Polish plural for "mecz": 1 mecz, 2-4 mecze, 5+ meczów (with the 12-14 exception).
+export function matchCountLabel(count: number): string {
+  if (count === 1) return '1 mecz'
+  const mod10 = count % 10
+  const mod100 = count % 100
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return `${count} mecze`
+  return `${count} meczów`
+}

--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -61,7 +61,9 @@ export default function MatchPage() {
         )}
         <div className="flex items-center justify-center gap-2 sm:gap-3">
           <div className="flex flex-1 items-center justify-end gap-4 text-right text-lg font-bold text-ink">
-            {match.team_a}
+            <Link to={`/teams/${encodeURIComponent(match.team_a)}`} className="hover:text-brand hover:underline">
+              {match.team_a}
+            </Link>
             <Flag team={match.team_a} className="h-5 w-7 shrink-0 rounded-sm" />
           </div>
           <div className="shrink-0 rounded-lg bg-surface px-4 py-2 text-2xl font-bold tabular-nums text-ink">
@@ -69,7 +71,9 @@ export default function MatchPage() {
           </div>
           <div className="flex flex-1 items-center gap-4 text-left text-lg font-bold text-ink">
             <Flag team={match.team_b} className="h-5 w-7 shrink-0 rounded-sm" />
-            {match.team_b}
+            <Link to={`/teams/${encodeURIComponent(match.team_b)}`} className="hover:text-brand hover:underline">
+              {match.team_b}
+            </Link>
           </div>
         </div>
         {live && (

--- a/frontend/src/pages/TeamPage.tsx
+++ b/frontend/src/pages/TeamPage.tsx
@@ -1,0 +1,145 @@
+import { Link, useParams } from 'react-router-dom'
+import { useMatches } from '@/api/hooks'
+import type { Match } from '@/api/types'
+import { ErrorBox, Loading } from '@/components/Status'
+import Flag from '@/components/Flag'
+import { formatDayMonth, formatTime, formattedScore } from '@/lib/format'
+import { matchCountLabel, teamOutcome, teamRecord, teamSchedule, type TeamOutcome } from '@/lib/teams'
+import { useDocumentTitle } from '@/lib/useDocumentTitle'
+
+// W/R/P badge for a finished match, from this team's perspective.
+const OUTCOME: Record<TeamOutcome, { label: string; title: string; cls: string }> = {
+  win: { label: 'W', title: 'Wygrana', cls: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300' },
+  draw: { label: 'R', title: 'Remis', cls: 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300' },
+  loss: { label: 'P', title: 'Porażka', cls: 'bg-rose-100 text-rose-700 dark:bg-rose-500/15 dark:text-rose-300' },
+}
+
+// A team name inside a row: the current team (the page you're on) is plain bold
+// text; the opponent links to its own history.
+function TeamName({ team, current }: { team: string; current: string }) {
+  if (team === current) return <span className="font-bold">{team}</span>
+  return (
+    <Link
+      to={`/teams/${encodeURIComponent(team)}`}
+      className="relative z-10 font-medium hover:text-brand hover:underline"
+    >
+      {team}
+    </Link>
+  )
+}
+
+// One row of the team's history: date, the match line (this team in bold, the
+// opponent a link to its page), and a result badge for finished matches or the
+// kick-off time for upcoming ones. The row opens the match via an overlay link
+// painted beneath the opponent's name link (anchors can't nest), so clicking the
+// opponent goes to their history and clicking anywhere else opens the match.
+function TeamMatchRow({ match, team }: { match: Match; team: string }) {
+  const outcome = teamOutcome(match, team)
+  const badge = outcome ? OUTCOME[outcome] : null
+  return (
+    <div className="group relative flex items-center gap-2 px-4 py-3 hover:bg-black/5 sm:gap-3 sm:px-5 dark:hover:bg-white/5">
+      <Link
+        to={`/matches/${match.id}`}
+        aria-label={`${match.team_a} – ${match.team_b}`}
+        className="absolute inset-0"
+      />
+      <span className="w-12 shrink-0 text-xs font-semibold tabular-nums text-muted">{formatDayMonth(match.start)}</span>
+      <span className="flex flex-1 items-center justify-center gap-2 sm:gap-3">
+        <span className="flex flex-1 items-center justify-end gap-2 text-right text-ink">
+          <TeamName team={match.team_a} current={team} />
+          <Flag team={match.team_a} className="h-3.5 w-5 shrink-0 rounded-sm" />
+        </span>
+        <span className="shrink-0 rounded-md bg-surface px-2 py-1 text-sm font-bold tabular-nums text-ink">
+          {formattedScore(match.result_a, match.result_b)}
+        </span>
+        <span className="flex flex-1 items-center gap-2 text-ink">
+          <Flag team={match.team_b} className="h-3.5 w-5 shrink-0 rounded-sm" />
+          <TeamName team={match.team_b} current={team} />
+        </span>
+      </span>
+      <span className="flex w-10 shrink-0 justify-end">
+        {badge ? (
+          <span
+            title={badge.title}
+            className={`inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold ${badge.cls}`}
+          >
+            {badge.label}
+          </span>
+        ) : (
+          <span className="text-xs font-medium tabular-nums text-muted">{formatTime(match.start)}</span>
+        )}
+      </span>
+    </div>
+  )
+}
+
+function MatchSection({ title, matches, team }: { title: string; matches: Match[]; team: string }) {
+  if (matches.length === 0) return null
+  return (
+    <section className="card overflow-hidden">
+      <div className="card-header">
+        <h3 className="text-sm font-bold text-muted">{title}</h3>
+      </div>
+      <div className="divide-y divide-line/60">
+        {matches.map((match) => (
+          <TeamMatchRow key={match.id} match={match} team={team} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+// A single team's match history, reachable by clicking a team name in a match.
+// Everything is derived client-side from the already-loaded match list — see
+// teamSchedule in @/lib/teams.
+export default function TeamPage() {
+  const { name = '' } = useParams()
+  const { data, isLoading, isError } = useMatches()
+
+  useDocumentTitle(name)
+
+  if (isLoading) return <Loading />
+  if (isError || !data) return <ErrorBox />
+
+  const { finished, upcoming } = teamSchedule(data, name)
+  const record = teamRecord(finished, name)
+  const empty = finished.length === 0 && upcoming.length === 0
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <Link to="/matches" className="inline-flex items-center gap-1 text-sm text-muted hover:text-brand">
+        <i className="fas fa-angle-left" aria-hidden="true" /> Mecze
+      </Link>
+
+      <section className="card card-body">
+        <div className="flex items-center gap-3">
+          <Flag team={name} className="h-6 w-9 shrink-0 rounded-sm" />
+          <h1 className="text-xl font-bold text-ink">{name}</h1>
+        </div>
+        {record.played > 0 && (
+          <p className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted">
+            <span>{matchCountLabel(record.played)}</span>
+            <span aria-hidden="true">·</span>
+            <span className="inline-flex items-center gap-1 font-semibold tabular-nums">
+              <span className="text-emerald-600 dark:text-emerald-400">{record.wins}</span>
+              <span className="text-muted/60">-</span>
+              <span className="text-amber-600 dark:text-amber-400">{record.draws}</span>
+              <span className="text-muted/60">-</span>
+              <span className="text-rose-600 dark:text-rose-400">{record.losses}</span>
+            </span>
+            <span className="text-xs">(W-R-P)</span>
+          </p>
+        )}
+      </section>
+
+      {empty ? (
+        <div className="card card-body text-center text-muted">Brak meczów dla tej drużyny.</div>
+      ) : (
+        <>
+          <MatchSection title="Zakończone" matches={finished} team={name} />
+          <MatchSection title="Nadchodzące" matches={upcoming} team={name} />
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Clicking a team name now opens /teams/:name, listing that team's finished matches (with a W/R/P badge and a W-D-L record summary) and upcoming fixtures. Everything is derived client-side from the already cached match list, so no API change is needed.

Team names are linked everywhere a match line appears (match detail, match list, user and virtual-player profiles). Since the row is already a link to the match and anchors can't nest, the match link is painted as an overlay beneath the raised team-name links: clicking a name goes to that team, clicking elsewhere opens the match.