### PR TITLE
Add a seed-parameterized strategy to the ranking

### DIFF
--- a/frontend/src/components/SeedStrategyCard.tsx
+++ b/frontend/src/components/SeedStrategyCard.tsx
@@ -1,0 +1,88 @@
+import { useMemo, useState } from 'react'
+import { useMatches, useRanking } from '@/api/hooks'
+import { pointsDisplay } from '@/lib/format'
+import { randomSeed, scoreSeed } from '@/lib/seedStrategy'
+
+// A toy strategy you parameterize with a word: its seed deterministically draws a
+// 1/X/2 pick on every finished match, and the card scores it live against the real
+// field. Everything runs in the browser off the cached match list, so it's instant
+// and private — the game is to find a seed that scores the most points.
+export default function SeedStrategyCard() {
+  const [open, setOpen] = useState(false)
+  const [seed, setSeed] = useState('')
+  const { data: matches } = useMatches()
+  const { data: ranking } = useRanking()
+
+  const finished = matches?.finished ?? []
+  const trimmed = seed.trim()
+  const score = useMemo(
+    () => (trimmed === '' || finished.length === 0 ? null : scoreSeed(trimmed, finished)),
+    [trimmed, finished],
+  )
+
+  const entries = ranking?.entries ?? []
+  const perfectScore = ranking?.perfect_score ?? 0
+  // Where this score would slot into the real field (ties land behind the players
+  // they match, hence "> points"); the field grows by one to include the seed.
+  const position = score ? entries.filter((entry) => entry.points > score.points).length + 1 : null
+  const share = score && perfectScore > 0 ? Math.round((score.points / perfectScore) * 100) : null
+
+  return (
+    <div className="card mb-4 overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 px-4 py-3 text-left hover:bg-black/5 dark:hover:bg-white/5"
+      >
+        <i className="fas fa-dice text-brand" aria-hidden="true" />
+        <span className="text-sm font-bold text-muted">Strategia z seeda</span>
+        <i
+          className={`fas fa-chevron-down ml-auto text-xs text-muted transition-transform ${open ? 'rotate-180' : ''}`}
+          aria-hidden="true"
+        />
+      </button>
+      {open && (
+        <div className="space-y-3 border-t border-line/60 px-4 py-3">
+          <p className="text-xs text-muted">
+            Wpisz słowo — z jego seeda deterministycznie losowane są typy (1/X/2) na każdy rozegrany mecz. Szukaj
+            takiego, który da najwięcej punktów.
+          </p>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={seed}
+              onChange={(event) => setSeed(event.target.value)}
+              placeholder="np. messi2026"
+              aria-label="Seed strategii"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              className="field flex-1"
+            />
+            <button
+              type="button"
+              onClick={() => setSeed(randomSeed())}
+              title="Losuj seed"
+              className="btn btn-outline btn-sm shrink-0"
+            >
+              <i className="fas fa-dice" aria-hidden="true" /> Losuj
+            </button>
+          </div>
+          {finished.length === 0 ? (
+            <p className="text-sm text-muted">Brak rozegranych meczów — nie ma jeszcze czego punktować.</p>
+          ) : score && position != null ? (
+            <div className="rounded-lg bg-surface px-3 py-2 text-sm leading-relaxed">
+              <span className="font-bold text-ink tabular-nums">{pointsDisplay(score.points)}</span> pkt
+              {share != null && <span className="text-muted"> ({share}%)</span>} ·{' '}
+              <span className="tabular-nums">{score.accuracy}</span> trafień ·{' '}
+              byłby <span className="font-bold text-ink tabular-nums">{position}.</span> / {entries.length + 1}
+            </div>
+          ) : (
+            <p className="text-sm text-muted">Wpisz seed, aby zobaczyć wynik.</p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/seedStrategy.test.ts
+++ b/frontend/src/lib/seedStrategy.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import type { BetType, Match, Odds } from '@/api/types'
+import { randomSeed, scoreSeed, seededPick } from './seedStrategy'
+
+const NO_ODDS: Odds = { win_a: null, tie: null, win_b: null, win_tie_a: null, win_tie_b: null, not_tie: null }
+
+function match(overrides: Partial<Match>): Match {
+  return {
+    id: 1,
+    team_a: 'A',
+    team_b: 'B',
+    start: '2026-06-12T18:00:00Z',
+    started: true,
+    finished: true,
+    result_a: 0,
+    result_b: 0,
+    odds: NO_ODDS,
+    my_answer: null,
+    my_locked: false,
+    ...overrides,
+  }
+}
+
+// A result that makes the given basic pick the winning outcome.
+function winningResult(pick: BetType): Partial<Match> {
+  if (pick === 'win_a') return { result_a: 2, result_b: 0 }
+  if (pick === 'win_b') return { result_a: 0, result_b: 2 }
+  return { result_a: 1, result_b: 1 }
+}
+
+describe('seededPick', () => {
+  it('is deterministic and only ever draws 1 / X / 2', () => {
+    expect(seededPick('messi', 7)).toBe(seededPick('messi', 7))
+    expect(['win_a', 'tie', 'win_b']).toContain(seededPick('whatever', 42))
+  })
+})
+
+describe('scoreSeed', () => {
+  it('scores the odds of a seeded pick when it wins', () => {
+    const seed = 'messi2026'
+    const pick = seededPick(seed, 7)
+    const m = match({ id: 7, ...winningResult(pick), odds: { ...NO_ODDS, [pick]: 2.5 } })
+    expect(scoreSeed(seed, [m])).toEqual({ points: 2.5, accuracy: 1 })
+  })
+
+  it('scores zero when the seeded pick loses', () => {
+    const seed = 'abc'
+    const pick = seededPick(seed, 3)
+    // Flip the result so the pick is not in the winning list.
+    const losing: Partial<Match> = pick === 'tie' ? { result_a: 1, result_b: 0 } : winningResult(pick === 'win_a' ? 'win_b' : 'win_a')
+    const m = match({ id: 3, ...losing, odds: { ...NO_ODDS, [pick]: 2.5 } })
+    expect(scoreSeed(seed, [m])).toEqual({ points: 0, accuracy: 0 })
+  })
+
+  it('is stable for the same seed', () => {
+    const finished = [
+      match({ id: 1, result_a: 2, result_b: 0, odds: { ...NO_ODDS, win_a: 1.8, tie: 3.2, win_b: 4.1 } }),
+      match({ id: 2, result_a: 1, result_b: 1, odds: { ...NO_ODDS, win_a: 2.0, tie: 3.0, win_b: 3.5 } }),
+      match({ id: 3, result_a: 0, result_b: 3, odds: { ...NO_ODDS, win_a: 5.0, tie: 3.4, win_b: 1.6 } }),
+    ]
+    expect(scoreSeed('lewy', finished)).toEqual(scoreSeed('lewy', finished))
+  })
+})
+
+describe('randomSeed', () => {
+  it('returns a non-empty alphanumeric string', () => {
+    expect(randomSeed()).toMatch(/^[a-z0-9]+$/)
+  })
+})

--- a/frontend/src/lib/seedStrategy.ts
+++ b/frontend/src/lib/seedStrategy.ts
@@ -1,0 +1,50 @@
+import type { BetType, Match } from '@/api/types'
+import { winningBets } from './bets'
+
+// The seeded strategy only ever draws among the three basic outcomes: 1 / X / 2.
+const OUTCOMES: BetType[] = ['win_a', 'tie', 'win_b']
+
+// FNV-1a 32-bit hash of a string → unsigned int. Small, synchronous and stable,
+// which is all the seeded picks need.
+function hash32(input: string): number {
+  let h = 2166136261
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  return h >>> 0
+}
+
+// The strategy's pick for one match. It depends only on (seed, matchId), so each
+// match's pick is fixed and independent of the others — adding a finished match
+// never shifts the picks already made, and "the best seed" stays well-defined.
+export function seededPick(seed: string, matchId: number): BetType {
+  return OUTCOMES[hash32(`${seed}|${matchId}`) % 3]
+}
+
+export interface SeedScore {
+  points: number
+  accuracy: number
+}
+
+// Score a seed over the finished matches with the same rule as a real bet: a pick
+// earns the match's odds for it when that outcome won, otherwise nothing. Mirrors
+// Typerek::Ranking::VirtualPlayers#score (odds rounded to 2dp, as in the backend).
+export function scoreSeed(seed: string, finished: Match[]): SeedScore {
+  let points = 0
+  let accuracy = 0
+  for (const match of finished) {
+    const pick = seededPick(seed, match.id)
+    if (!winningBets(match.result_a, match.result_b).includes(pick)) continue
+    const odds = match.odds[pick]
+    if (odds == null) continue
+    points += Math.round(odds * 100) / 100
+    accuracy += 1
+  }
+  return { points: Math.round(points * 100) / 100, accuracy }
+}
+
+// A short random seed for the "roll the dice" button.
+export function randomSeed(): string {
+  return Math.random().toString(36).slice(2, 8)
+}

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/auth/AuthContext'
 import { ErrorBox, Loading } from '@/components/Status'
 import RankingBumpChart from '@/components/RankingBumpChart'
 import RankingPointsChart from '@/components/RankingPointsChart'
+import SeedStrategyCard from '@/components/SeedStrategyCard'
 import { pointsDisplay } from '@/lib/format'
 import { useSettings } from '@/lib/settings'
 import { useDocumentTitle } from '@/lib/useDocumentTitle'
@@ -374,6 +375,7 @@ export default function RankingPage() {
               </button>
             </div>
           </div>
+          <SeedStrategyCard />
           {visible.length === 0 ? (
             <div className="card card-body text-center text-muted">
               {query.trim()


### PR DESCRIPTION
A toy "virtual player" you steer with a word: its seed deterministically draws a 1/X/2 pick on every finished match (a per-match FNV-1a hash, so a pick depends only on the seed and that match), scored with the same odds-on-a-hit rule as a real bet. A collapsible "Strategia z seeda" card on the ranking table scores it live against the field — points, hits and where it would place — and a "Losuj" button rolls a random seed.

Everything runs client-side off the cached match list (odds + results) and reuses winningBets, so it's instant and needs no backend; the game of finding the best seed stays personal and ephemeral.