### PR TITLE
Add settings toggles for virtual players and the seed strategy

### DIFF
--- a/app/controllers/api/v1/profile_controller.rb
+++ b/app/controllers/api/v1/profile_controller.rb
@@ -36,7 +36,7 @@ module Api
       # integers with the user's own id stripped (you can't favourite yourself).
       def settings_params
         permitted = params.require(:settings).permit(
-          :drzewko_mode, :bet_lock, :match_order_by_ranking, :virtual_players,
+          :drzewko_mode, :bet_lock, :match_order_by_ranking, :virtual_players, :seed_strategy,
           :push_enabled, :push_results, :push_reminders, :theme,
           favorite_user_ids: []
         ).to_h

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,10 @@ class User < ApplicationRecord
     'match_order_by_ranking' => false,
     # Show three naive benchmark "players" (always-favourite / always-underdog /
     # always-draw) interleaved in the ranking, to compare against. Opt-in.
-    'virtual_players' => false
+    'virtual_players' => false,
+    # Show the experimental seed-driven strategy in the ranking (inside the virtual
+    # players overlay). Opt-in, off by default.
+    'seed_strategy' => false
   }.freeze
 
   # Allowed values for the `theme` setting. Anything else falls back to 'light'.
@@ -34,7 +37,8 @@ class User < ApplicationRecord
   # Settings we surface a "Włączone przez N osób" count for on the settings screen.
   # The push sub-toggles are excluded: they default on, so a raw `= 'true'` count
   # would be meaningless for them.
-  COUNTED_SETTINGS = %w[drzewko_mode bet_lock push_enabled match_order_by_ranking virtual_players].freeze
+  COUNTED_SETTINGS = %w[drzewko_mode bet_lock push_enabled match_order_by_ranking virtual_players
+                        seed_strategy].freeze
 
   has_secure_password validations: false
 
@@ -108,6 +112,10 @@ class User < ApplicationRecord
 
   def virtual_players?
     settings_with_defaults['virtual_players'] == true
+  end
+
+  def seed_strategy?
+    settings_with_defaults['seed_strategy'] == true
   end
 
   def push_enabled?

--- a/app/serializers/api/v1/current_user_serializer.rb
+++ b/app/serializers/api/v1/current_user_serializer.rb
@@ -27,7 +27,8 @@ module Api
             theme: user.theme,
             favorite_user_ids: user.favorite_user_ids,
             match_order_by_ranking: user.match_order_by_ranking?,
-            virtual_players: user.virtual_players?
+            virtual_players: user.virtual_players?,
+            seed_strategy: user.seed_strategy?
           }
         }
       end

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -38,6 +38,9 @@ export interface UserSettings {
   match_order_by_ranking: boolean
   // Show the naive benchmark "players" interleaved in the ranking.
   virtual_players: boolean
+  // Show the experimental seed-driven strategy in the ranking (within the virtual
+  // players overlay). Opt-in, off by default.
+  seed_strategy: boolean
 }
 
 // A registered Web Push device for the signed-in user (GET /push/subscriptions).

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -38,6 +38,9 @@ interface Settings {
   matchOrderByRanking: boolean
   // Interleave the naive benchmark "players" into the ranking. Opt-in.
   virtualPlayers: boolean
+  // Show the experimental seed-driven strategy in the ranking (within the virtual
+  // players overlay). Opt-in, off by default.
+  seedStrategy: boolean
 }
 
 const DEFAULTS: Settings = {
@@ -50,6 +53,7 @@ const DEFAULTS: Settings = {
   favoriteUserIds: [],
   matchOrderByRanking: false,
   virtualPlayers: false,
+  seedStrategy: false,
 }
 
 // Map between the server shape (snake_case, the API contract) and ours (camelCase).
@@ -68,6 +72,7 @@ function fromServer(settings: UserSettings | undefined): Settings {
     favoriteUserIds: settings?.favorite_user_ids ?? DEFAULTS.favoriteUserIds,
     matchOrderByRanking: settings?.match_order_by_ranking ?? DEFAULTS.matchOrderByRanking,
     virtualPlayers: settings?.virtual_players ?? DEFAULTS.virtualPlayers,
+    seedStrategy: settings?.seed_strategy ?? DEFAULTS.seedStrategy,
   }
 }
 
@@ -84,6 +89,7 @@ interface SettingsState extends Settings {
   toggleFavorite: (userId: number) => Promise<void>
   setMatchOrderByRanking: (value: boolean) => Promise<void>
   setVirtualPlayers: (value: boolean) => Promise<void>
+  setSeedStrategy: (value: boolean) => Promise<void>
 }
 
 const SettingsContext = createContext<SettingsState | undefined>(undefined)
@@ -145,6 +151,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       persist({ matchOrderByRanking }, { match_order_by_ranking: matchOrderByRanking }),
     setVirtualPlayers: (virtualPlayers) =>
       persist({ virtualPlayers }, { virtual_players: virtualPlayers }),
+    setSeedStrategy: (seedStrategy) => persist({ seedStrategy }, { seed_strategy: seedStrategy }),
   }
 
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -95,7 +95,8 @@ function parseView(param: string | null): View {
 export default function RankingPage() {
   const { data, isLoading, isError } = useRanking()
   const { user } = useAuth()
-  const { drzewkoMode, favoriteUserIds, toggleFavorite, virtualPlayers, setVirtualPlayers } = useSettings()
+  const { drzewkoMode, favoriteUserIds, toggleFavorite, virtualPlayers, setVirtualPlayers, seedStrategy } =
+    useSettings()
   const meRowRef = useRef<HTMLLIElement>(null)
   const [query, setQuery] = useState('')
   const [favoritesOnly, setFavoritesOnly] = useState(false)
@@ -168,11 +169,13 @@ export default function RankingPage() {
     virtualKey: vp.key,
   }))
 
-  // The seed strategy joins the same overlay when a seed is set: an account-less
-  // row (virtualKey marks it as one for all the rank-less handling) slotted by its
+  // The seed strategy joins the same overlay when a seed is set — but only when the
+  // (opt-in, off by default) seed_strategy setting is on. An account-less row
+  // (virtualKey marks it as one for all the rank-less handling) slotted by its
   // score, but flagged `seed` so it renders with the seed word, not a profile link.
-  const seedRow: RankRow | null = seedScore
-    ? {
+  const seedRow: RankRow | null =
+    seedStrategy && seedScore
+      ? {
         position: 0,
         previous_position: null,
         user: { id: SEED_ROW_ID, username: trimmedSeed },
@@ -395,7 +398,7 @@ export default function RankingPage() {
                 type="button"
                 onClick={() => void setVirtualPlayers(!virtualPlayers)}
                 aria-pressed={virtualPlayers}
-                title="Pokaż w rankingu strategie-benchmarki (Faworyt, Underdog, Remis) i strategię z seeda"
+                title="Pokaż w rankingu strategie-benchmarki: Faworyt, Underdog, Drugi kurs, Remis"
                 className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
                   virtualPlayers
                     ? 'border-brand bg-brand-tint text-brand'
@@ -407,7 +410,7 @@ export default function RankingPage() {
               </button>
             </div>
           </div>
-          {virtualPlayers && <SeedStrategyCard seed={seed} onSeedChange={setSeed} />}
+          {virtualPlayers && seedStrategy && <SeedStrategyCard seed={seed} onSeedChange={setSeed} />}
           {visible.length === 0 ? (
             <div className="card card-body text-center text-muted">
               {query.trim()

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -24,6 +24,8 @@ type SettingsStats = {
   bet_lock: number
   push_enabled: number
   match_order_by_ranking: number
+  virtual_players: number
+  seed_strategy: number
   // How many users have dark mode on (theme 'dark' or 'auto').
   theme: number
 }
@@ -83,6 +85,10 @@ export default function SettingsPage() {
     setBetLock,
     matchOrderByRanking,
     setMatchOrderByRanking,
+    virtualPlayers,
+    setVirtualPlayers,
+    seedStrategy,
+    setSeedStrategy,
     pushResults,
     setPushResults,
     pushReminders,
@@ -367,6 +373,46 @@ export default function SettingsPage() {
             <UsageHint count={stats?.match_order_by_ranking} />
           </span>
         </label>
+
+        <div>
+          <label className="flex cursor-pointer items-start gap-3 px-4 py-4 sm:px-5">
+            <input
+              type="checkbox"
+              className="mt-0.5 h-5 w-5 shrink-0 accent-brand"
+              checked={virtualPlayers}
+              onChange={(event) => toggle('virtual_players', setVirtualPlayers, event.target.checked)}
+            />
+            <span className="leading-snug">
+              <span className="block font-semibold text-ink">Wirtualni gracze</span>
+              <span className="block text-muted">
+                Dodaje do rankingu strategie-benchmarki (Faworyt, Underdog, Drugi kurs, Remis), żeby
+                porównać swoje typy. To samo można włączyć przyciskiem na widoku rankingu.
+              </span>
+              <UsageHint count={stats?.virtual_players} />
+            </span>
+          </label>
+
+          {virtualPlayers && (
+            <div className="border-t border-line/40 bg-surface/40 px-4 py-3 pl-12 sm:px-5 sm:pl-14">
+              <label className="flex cursor-pointer items-start gap-3">
+                <input
+                  type="checkbox"
+                  className="mt-0.5 h-4 w-4 shrink-0 accent-brand"
+                  checked={seedStrategy}
+                  onChange={(event) => toggle('seed_strategy', setSeedStrategy, event.target.checked)}
+                />
+                <span className="leading-snug">
+                  <span className="block text-sm font-medium text-ink">Strategia z seeda</span>
+                  <span className="block text-xs text-muted">
+                    Eksperymentalna strategia sterowana słowem — z jego seeda losowane są typy 1/X/2.
+                    Pojawia się w rankingu jako dodatkowy gracz. Domyślnie ukryta.
+                  </span>
+                  <UsageHint count={stats?.seed_strategy} />
+                </span>
+              </label>
+            </div>
+          )}
+        </div>
       </section>
     </>
   )

--- a/spec/requests/api/v1/profile_spec.rb
+++ b/spec/requests/api/v1/profile_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'API V1 Profile', type: :request do
         'drzewko_mode' => false, 'bet_lock' => false, 'push_enabled' => false,
         'push_results' => true, 'push_reminders' => true, 'theme' => 'light',
         'favorite_user_ids' => [], 'match_order_by_ranking' => false,
-        'virtual_players' => false
+        'virtual_players' => false, 'seed_strategy' => false
       )
     end
 
@@ -48,7 +48,7 @@ RSpec.describe 'API V1 Profile', type: :request do
       expect(response).to have_http_status(:ok)
       expect(json).to eq(
         'drzewko_mode' => 2, 'bet_lock' => 1, 'push_enabled' => 0,
-        'match_order_by_ranking' => 1, 'virtual_players' => 1, 'theme' => 2
+        'match_order_by_ranking' => 1, 'virtual_players' => 1, 'seed_strategy' => 0, 'theme' => 2
       )
     end
 
@@ -70,7 +70,7 @@ RSpec.describe 'API V1 Profile', type: :request do
         'drzewko_mode' => false, 'bet_lock' => true, 'push_enabled' => false,
         'push_results' => true, 'push_reminders' => true, 'theme' => 'light',
         'favorite_user_ids' => [], 'match_order_by_ranking' => false,
-        'virtual_players' => false
+        'virtual_players' => false, 'seed_strategy' => false
       )
       expect(user.reload.bet_lock?).to be(true)
     end
@@ -91,6 +91,15 @@ RSpec.describe 'API V1 Profile', type: :request do
       expect(response).to have_http_status(:ok)
       expect(json['settings']).to include('virtual_players' => true)
       expect(user.reload.virtual_players?).to be(true)
+    end
+
+    it 'updates the seed-strategy preference' do
+      patch '/api/v1/me/settings', params: { settings: { seed_strategy: true } },
+            headers: auth_headers(user), as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json['settings']).to include('seed_strategy' => true)
+      expect(user.reload.seed_strategy?).to be(true)
     end
 
     it 'accepts a valid theme preference' do


### PR DESCRIPTION
Surface the virtual-players overlay as a setting on the settings screen (besides the existing ranking-page button — same persisted flag), and add a new opt-in seed_strategy setting nested under it. The seed strategy is now hidden by default and only shows in the ranking when virtual players are on and seed_strategy is enabled.

Backend wires seed_strategy like the other jsonb settings (defaults, predicate, counted setting, serializer, permitted param) — no migration needed. Profile specs updated for the new key, with a PATCH test added.