### PR TITLE
Add a rule-driven strategy (programmable bot) to the ranking

### DIFF
--- a/app/controllers/api/v1/profile_controller.rb
+++ b/app/controllers/api/v1/profile_controller.rb
@@ -36,7 +36,7 @@ module Api
       # integers with the user's own id stripped (you can't favourite yourself).
       def settings_params
         permitted = params.require(:settings).permit(
-          :drzewko_mode, :bet_lock, :match_order_by_ranking, :virtual_players, :seed_strategy,
+          :drzewko_mode, :bet_lock, :match_order_by_ranking, :virtual_players, :seed_strategy, :rule_strategy,
           :push_enabled, :push_results, :push_reminders, :theme,
           favorite_user_ids: []
         ).to_h

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,10 @@ class User < ApplicationRecord
     'virtual_players' => false,
     # Show the experimental seed-driven strategy in the ranking (inside the virtual
     # players overlay). Opt-in, off by default.
-    'seed_strategy' => false
+    'seed_strategy' => false,
+    # Show the experimental rule-driven strategy in the ranking (inside the virtual
+    # players overlay). Opt-in, off by default.
+    'rule_strategy' => false
   }.freeze
 
   # Allowed values for the `theme` setting. Anything else falls back to 'light'.
@@ -38,7 +41,7 @@ class User < ApplicationRecord
   # The push sub-toggles are excluded: they default on, so a raw `= 'true'` count
   # would be meaningless for them.
   COUNTED_SETTINGS = %w[drzewko_mode bet_lock push_enabled match_order_by_ranking virtual_players
-                        seed_strategy].freeze
+                        seed_strategy rule_strategy].freeze
 
   has_secure_password validations: false
 
@@ -116,6 +119,10 @@ class User < ApplicationRecord
 
   def seed_strategy?
     settings_with_defaults['seed_strategy'] == true
+  end
+
+  def rule_strategy?
+    settings_with_defaults['rule_strategy'] == true
   end
 
   def push_enabled?

--- a/app/serializers/api/v1/current_user_serializer.rb
+++ b/app/serializers/api/v1/current_user_serializer.rb
@@ -28,7 +28,8 @@ module Api
             favorite_user_ids: user.favorite_user_ids,
             match_order_by_ranking: user.match_order_by_ranking?,
             virtual_players: user.virtual_players?,
-            seed_strategy: user.seed_strategy?
+            seed_strategy: user.seed_strategy?,
+            rule_strategy: user.rule_strategy?
           }
         }
       end

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -41,6 +41,9 @@ export interface UserSettings {
   // Show the experimental seed-driven strategy in the ranking (within the virtual
   // players overlay). Opt-in, off by default.
   seed_strategy: boolean
+  // Show the experimental rule-driven strategy in the ranking (within the virtual
+  // players overlay). Opt-in, off by default.
+  rule_strategy: boolean
 }
 
 // A registered Web Push device for the signed-in user (GET /push/subscriptions).

--- a/frontend/src/components/RuleStrategyCard.tsx
+++ b/frontend/src/components/RuleStrategyCard.tsx
@@ -1,0 +1,175 @@
+import { useMemo, useState } from 'react'
+import { useMatches, useRanking } from '@/api/hooks'
+import MatchLine from '@/components/MatchLine'
+import BetGrid from '@/components/BetGrid'
+import { formatDateLong, groupByDay, pointsDisplay } from '@/lib/format'
+import { OPERATOR_HELP, TOKEN_HELP, parseRules, rulePick, scoreRules } from '@/lib/ruleStrategy'
+
+interface Props {
+  rules: string
+  onRulesChange: (rules: string) => void
+}
+
+const EXAMPLE = `w1 < 1.3 & r > 5 => r
+w1 < w2 => w1
+=> w2`
+
+// Controls the rule strategy: a "virtual player" you parameterize with a little
+// `condition => pick` program (see lib/ruleStrategy). The rules deterministically
+// pick 1/X/2 (and the double chances) per match, scored live off the cached match
+// list. The text lives in RankingPage so the strategy can also appear as a ranking
+// row; this card is the editor plus a syntax cheat-sheet and a "Podejrzyj typy"
+// preview of the rules' pick on every started match. A sibling of SeedStrategyCard;
+// rendered only while the "Wirtualni gracze" overlay is on.
+export default function RuleStrategyCard({ rules, onRulesChange }: Props) {
+  const [showPicks, setShowPicks] = useState(false)
+  const [showHelp, setShowHelp] = useState(false)
+  const { data: matches } = useMatches()
+  const { data: ranking } = useRanking()
+
+  const finished = matches?.finished ?? []
+  const hasRules = rules.trim() !== ''
+  const parsed = useMemo(() => parseRules(rules), [rules])
+  const score = useMemo(
+    () => (!parsed.ok || finished.length === 0 ? null : scoreRules(parsed.rules, finished)),
+    [parsed, finished],
+  )
+
+  // Started matches (finished + live), newest first — the same set the player and
+  // virtual-strategy profiles show their picks over.
+  const started = useMemo(() => {
+    const fin = matches?.finished ?? []
+    const live = (matches?.not_finished ?? []).filter((match) => match.started)
+    return [...fin, ...live].sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime())
+  }, [matches])
+
+  const perfectScore = ranking?.perfect_score ?? 0
+  const share = score && perfectScore > 0 ? Math.round((score.points / perfectScore) * 100) : null
+  const canPreview = parsed.ok && started.length > 0
+
+  return (
+    <>
+      <div className="card mb-4 overflow-hidden">
+        <div className="card-header">
+          <h3 className="flex items-center gap-2 text-sm font-bold text-muted">
+            <i className="fas fa-code text-brand" aria-hidden="true" /> Strategia regułowa
+          </h3>
+        </div>
+        <div className="space-y-3 px-4 py-3">
+          <p className="text-xs text-muted">
+            Napisz reguły <code className="rounded bg-surface px-1 py-0.5 text-ink">warunek =&gt; typ</code>, po
+            jednej w linii. Czytane od góry — wygrywa pierwsza pasująca; reguła bez warunku to wartość domyślna.
+            Punktowane jak realny zakład: trafiony typ daje swój kurs.
+          </p>
+
+          {/* Syntax cheat-sheet — collapsed by default, but the trigger and a one-line
+              summary keep the available tokens/operators in view. */}
+          <div className="rounded-lg border border-line bg-surface/40 text-xs">
+            <button
+              type="button"
+              onClick={() => setShowHelp((value) => !value)}
+              aria-expanded={showHelp}
+              className="flex w-full items-center gap-1.5 px-3 py-2 font-medium text-muted hover:text-ink"
+            >
+              <i className={`fas fa-chevron-${showHelp ? 'up' : 'down'} text-[10px]`} aria-hidden="true" />
+              Składnia
+            </button>
+            {showHelp && (
+              <div className="space-y-2 border-t border-line/60 px-3 py-2">
+                <p className="text-muted">
+                  Zmienne (kursy) i typy używają tych samych nazw — po lewej stronie to kurs danego wyniku, po
+                  <code className="mx-1 rounded bg-surface px-1 text-ink">=&gt;</code> to typ na ten wynik:
+                </p>
+                <ul className="grid grid-cols-1 gap-x-4 gap-y-0.5 sm:grid-cols-2">
+                  {TOKEN_HELP.map(([token, label]) => (
+                    <li key={token} className="flex items-baseline gap-2">
+                      <code className="rounded bg-surface px-1.5 py-0.5 font-bold text-ink">{token}</code>
+                      <span className="text-muted">{label}</span>
+                    </li>
+                  ))}
+                </ul>
+                <p className="text-muted">
+                  Operatory: <span className="text-ink">{OPERATOR_HELP}</span>
+                </p>
+                <p className="text-muted">
+                  Można porównywać kurs z liczbą (<code className="rounded bg-surface px-1 text-ink">w1 &lt; 1.3</code>)
+                  albo dwa kursy (<code className="rounded bg-surface px-1 text-ink">w1 &lt; w2</code>). Komentarze po{' '}
+                  <code className="rounded bg-surface px-1 text-ink">#</code>.
+                </p>
+              </div>
+            )}
+          </div>
+
+          <textarea
+            value={rules}
+            onChange={(event) => onRulesChange(event.target.value)}
+            placeholder={EXAMPLE}
+            aria-label="Reguły strategii"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            rows={4}
+            className="field w-full resize-y font-mono text-sm leading-relaxed"
+          />
+
+          {!hasRules ? (
+            <p className="text-sm text-muted">Wpisz reguły, aby zobaczyć wynik.</p>
+          ) : !parsed.ok ? (
+            <p className="text-sm font-medium text-red-600 dark:text-red-400">
+              <i className="fas fa-triangle-exclamation mr-1" aria-hidden="true" />
+              {parsed.error}
+            </p>
+          ) : finished.length === 0 ? (
+            <p className="text-sm text-muted">Brak rozegranych meczów — nie ma jeszcze czego punktować.</p>
+          ) : score ? (
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+              <span>
+                <span className="font-bold text-ink tabular-nums">{pointsDisplay(score.points)}</span> pkt
+                {share != null && <span className="text-muted"> ({share}%)</span>} ·{' '}
+                <span className="tabular-nums">{score.accuracy}</span> trafień
+              </span>
+              {canPreview && (
+                <button
+                  type="button"
+                  onClick={() => setShowPicks((value) => !value)}
+                  aria-expanded={showPicks}
+                  className="inline-flex items-center gap-1.5 font-medium text-brand hover:underline"
+                >
+                  <i className={`fas fa-chevron-${showPicks ? 'up' : 'down'} text-xs`} aria-hidden="true" />
+                  {showPicks ? 'Ukryj typy' : 'Podejrzyj typy'}
+                </button>
+              )}
+            </div>
+          ) : null}
+        </div>
+      </div>
+      {showPicks && canPreview && parsed.ok && (
+        <div className="mb-4 space-y-4">
+          {groupByDay(started).map((group) => (
+            <section key={group.start} className="card overflow-hidden">
+              <div className="card-header">
+                <h3 className="text-sm font-bold text-muted">{formatDateLong(group.start)}</h3>
+              </div>
+              <div className="divide-y divide-line/60">
+                {group.items.map((match) => (
+                  // Always stacked (MatchLine over a full-width BetGrid): the ranking
+                  // column is narrow (max-w-xl), so a side-by-side layout would squeeze
+                  // MatchLine and misalign it here. Mirrors SeedStrategyCard's preview.
+                  <div
+                    key={match.id}
+                    className={`flex flex-col gap-2 px-4 py-3 sm:px-5${
+                      match.started && !match.finished ? ' bg-highlight/70' : ''
+                    }`}
+                  >
+                    <MatchLine match={match} />
+                    <BetGrid match={match} myAnswer={rulePick(parsed.rules, match)} />
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </>
+  )
+}

--- a/frontend/src/lib/ruleStrategy.test.ts
+++ b/frontend/src/lib/ruleStrategy.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import type { Match, Odds } from '@/api/types'
+import { parseRules, rulePick, scoreRules, type Rule } from './ruleStrategy'
+
+const NO_ODDS: Odds = { win_a: null, tie: null, win_b: null, win_tie_a: null, win_tie_b: null, not_tie: null }
+
+function match(overrides: Partial<Match>): Match {
+  return {
+    id: 1,
+    team_a: 'A',
+    team_b: 'B',
+    start: '2026-06-12T18:00:00Z',
+    started: true,
+    finished: true,
+    result_a: 0,
+    result_b: 0,
+    odds: NO_ODDS,
+    my_answer: null,
+    my_locked: false,
+    ...overrides,
+  }
+}
+
+// Parse a program for the tests, blowing up loudly if it doesn't compile.
+function rules(source: string): Rule[] {
+  const parsed = parseRules(source)
+  if (!parsed.ok) throw new Error(parsed.error)
+  return parsed.rules
+}
+
+describe('parseRules', () => {
+  it('parses a multi-rule program, ignoring blanks and comments', () => {
+    const parsed = parseRules(`
+      w1 < 1.3 & r > 5 => r   # juicy draw
+      w1 < w2 => w1
+
+      => w2
+    `)
+    expect(parsed).toMatchObject({ ok: true })
+    if (parsed.ok) expect(parsed.rules).toHaveLength(3)
+  })
+
+  it('reports a friendly error for an unknown pick', () => {
+    expect(parseRules('w1 < 1.3 => zz')).toMatchObject({ ok: false, error: expect.stringContaining('typ') })
+  })
+
+  it('reports a missing arrow, an unknown variable, and an empty program', () => {
+    expect(parseRules('w1 < 1.3 r')).toMatchObject({ ok: false })
+    expect(parseRules('foo < 1 => w1')).toMatchObject({ ok: false, error: expect.stringContaining('foo') })
+    expect(parseRules('   ')).toMatchObject({ ok: false })
+  })
+})
+
+describe('rulePick', () => {
+  const program = rules(`
+    w1 < 1.3 & r > 5 => r
+    w1 < w2 => w1
+    => w2
+  `)
+
+  it('returns the pick of the first matching rule', () => {
+    // Big home favourite with a juicy draw price → the first rule fires.
+    expect(rulePick(program, match({ odds: { ...NO_ODDS, win_a: 1.2, tie: 6, win_b: 12 } }))).toBe('tie')
+    // Home favourite, draw not juicy → falls to the head-to-head rule.
+    expect(rulePick(program, match({ odds: { ...NO_ODDS, win_a: 1.8, tie: 3.2, win_b: 4.1 } }))).toBe('win_a')
+    // Away favourite → falls through to the default.
+    expect(rulePick(program, match({ odds: { ...NO_ODDS, win_a: 4.1, tie: 3.2, win_b: 1.8 } }))).toBe('win_b')
+  })
+
+  it('treats a comparison against a missing odd as false and falls through', () => {
+    // tie is null, so `r > 5` can't hold; w1 < w2 still does → win_a.
+    expect(rulePick(program, match({ odds: { ...NO_ODDS, win_a: 1.2, win_b: 5 } }))).toBe('win_a')
+  })
+
+  it('returns null when nothing matches and there is no default', () => {
+    expect(rulePick(rules('w1 < 1 => w1'), match({ odds: { ...NO_ODDS, win_a: 2 } }))).toBeNull()
+  })
+})
+
+describe('scoreRules', () => {
+  it('scores the odds of each winning pick and counts the hits', () => {
+    const program = rules('w1 < w2 => w1\n=> w2')
+    const finished = [
+      // Home favourite, home wins → win_a @ 1.5.
+      match({ id: 1, result_a: 2, result_b: 0, odds: { ...NO_ODDS, win_a: 1.5, win_b: 4 } }),
+      // Away favourite (default), away wins → win_b @ 1.6.
+      match({ id: 2, result_a: 0, result_b: 1, odds: { ...NO_ODDS, win_a: 4, win_b: 1.6 } }),
+      // Home favourite but a draw → win_a misses, scores nothing.
+      match({ id: 3, result_a: 1, result_b: 1, odds: { ...NO_ODDS, win_a: 1.4, win_b: 5 } }),
+    ]
+    expect(scoreRules(program, finished)).toEqual({ points: 3.1, accuracy: 2 })
+  })
+
+  it('scores zero for a match the rules make no pick on', () => {
+    const m = match({ result_a: 2, result_b: 0, odds: { ...NO_ODDS, win_a: 1.5 } })
+    expect(scoreRules(rules('w1 < 1 => w1'), [m])).toEqual({ points: 0, accuracy: 0 })
+  })
+})

--- a/frontend/src/lib/ruleStrategy.ts
+++ b/frontend/src/lib/ruleStrategy.ts
@@ -1,0 +1,186 @@
+import type { BetType, Match } from '@/api/types'
+import { winningBets } from './bets'
+
+// A tiny rule language for a "virtual player": a list of `condition => pick` lines,
+// read top-down, first match wins. A line without a condition is the default. The
+// pick is scored like a real bet (see scoreRules), so you can hunt for a rule set
+// that would have paid off over the finished matches. A sibling of the seed
+// strategy (see seedStrategy.ts) — same scoring, but driven by explicit rules.
+//
+// Example:
+//   w1 < 1.3 & r > 5 => r     # big favourite but a juicy draw price → back the draw
+//   w1 < w2          => w1     # home favourite → back the home win
+//                    => w2     # otherwise → back the away win
+
+// The six outcomes a rule can name. On the left of a comparison a token stands for
+// that outcome's odds; after `=>` it means "bet that outcome". The same small set
+// both sides keeps the language unambiguous — no bare `1`/`2` that could be read as
+// a number. The keys double as Odds keys / BetTypes.
+const OUTCOMES: Record<string, BetType> = {
+  w1: 'win_a',
+  r: 'tie',
+  w2: 'win_b',
+  w1r: 'win_tie_a',
+  rw2: 'win_tie_b',
+  w12: 'not_tie',
+}
+
+// Token → human label, the single source of truth for the UI's syntax help.
+export const TOKEN_HELP: ReadonlyArray<readonly [string, string]> = [
+  ['w1', 'wygrana gospodarzy (1)'],
+  ['r', 'remis (X)'],
+  ['w2', 'wygrana gości (2)'],
+  ['w1r', '1 lub remis (1X)'],
+  ['rw2', 'remis lub 2 (X2)'],
+  ['w12', 'bez remisu (12)'],
+]
+
+export const OPERATOR_HELP = '< · <= · > · >= · = ·  łączenie: & (oraz) · | (lub)'
+
+type Op = '<' | '<=' | '>' | '>=' | '='
+
+type Operand = { kind: 'num'; value: number } | { kind: 'odds'; outcome: BetType }
+
+interface Comparison {
+  left: Operand
+  op: Op
+  right: Operand
+}
+
+// A condition is an OR of ANDs of comparisons (`&` binds tighter than `|`). A null
+// condition is the default rule, which always matches.
+type Condition = Comparison[][]
+
+export interface Rule {
+  condition: Condition | null
+  pick: BetType
+}
+
+export type ParseResult = { ok: true; rules: Rule[] } | { ok: false; error: string }
+
+export interface RuleScore {
+  points: number
+  accuracy: number
+}
+
+// Thrown while parsing, carrying a ready-to-show Polish message; caught and turned
+// into a ParseResult by parseRules so callers never see the exception.
+class RuleError extends Error {}
+
+// One side of a comparison: a number literal, or an outcome token (its odds).
+function operand(token: string): Operand | null {
+  if (/^\d/.test(token)) {
+    const value = Number(token)
+    return Number.isFinite(value) ? { kind: 'num', value } : null
+  }
+  const outcome = OUTCOMES[token]
+  return outcome ? { kind: 'odds', outcome } : null
+}
+
+const COMPARISON = /^([A-Za-z][A-Za-z0-9]*|\d+(?:\.\d+)?)\s*(<=|>=|==|=|<|>)\s*([A-Za-z][A-Za-z0-9]*|\d+(?:\.\d+)?)$/
+
+function parseComparison(text: string, line: number): Comparison {
+  const match = COMPARISON.exec(text.trim())
+  if (!match) throw new RuleError(`Linia ${line}: nie rozumiem warunku „${text.trim()}”.`)
+  const left = operand(match[1])
+  if (!left) throw new RuleError(`Linia ${line}: nieznana nazwa „${match[1]}”.`)
+  const right = operand(match[3])
+  if (!right) throw new RuleError(`Linia ${line}: nieznana nazwa „${match[3]}”.`)
+  return { left, op: (match[2] === '==' ? '=' : match[2]) as Op, right }
+}
+
+function parseCondition(text: string, line: number): Condition {
+  return text.split('|').map((group) => {
+    const parts = group.split('&').map((part) => part.trim())
+    if (parts.some((part) => part === '')) {
+      throw new RuleError(`Linia ${line}: pusty warunek wokół „&” lub „|”.`)
+    }
+    return parts.map((part) => parseComparison(part, line))
+  })
+}
+
+// Parse a multi-line program into rules, or return the first error (with its line)
+// for the UI to show. Blank lines and `#` comments are ignored.
+export function parseRules(source: string): ParseResult {
+  const rules: Rule[] = []
+  try {
+    source.split('\n').forEach((raw, index) => {
+      const line = index + 1
+      const text = raw.replace(/#.*$/, '').trim()
+      if (text === '') return
+
+      const arrow = text.indexOf('=>')
+      if (arrow === -1) throw new RuleError(`Linia ${line}: brakuje „=>” (warunek => typ).`)
+
+      const condText = text.slice(0, arrow).trim()
+      const pickText = text.slice(arrow + 2).trim()
+      const pick = OUTCOMES[pickText]
+      if (!pick) {
+        throw new RuleError(`Linia ${line}: „${pickText || '∅'}” to nie jest typ (użyj w1 r w2 w1r rw2 w12).`)
+      }
+
+      rules.push({ condition: condText === '' ? null : parseCondition(condText, line), pick })
+    })
+  } catch (error) {
+    if (error instanceof RuleError) return { ok: false, error: error.message }
+    throw error
+  }
+
+  if (rules.length === 0) return { ok: false, error: 'Brak reguł — dodaj choć jedną: warunek => typ.' }
+  return { ok: true, rules }
+}
+
+function evalOperand(op: Operand, match: Match): number | null {
+  return op.kind === 'num' ? op.value : match.odds[op.outcome]
+}
+
+function evalComparison(comparison: Comparison, match: Match): boolean {
+  const left = evalOperand(comparison.left, match)
+  const right = evalOperand(comparison.right, match)
+  // A comparison against a missing odd is simply false, so the rule falls through
+  // to the next one (or the default) instead of the whole program failing.
+  if (left == null || right == null) return false
+  switch (comparison.op) {
+    case '<':
+      return left < right
+    case '<=':
+      return left <= right
+    case '>':
+      return left > right
+    case '>=':
+      return left >= right
+    case '=':
+      return left === right
+  }
+}
+
+function conditionMatches(condition: Condition, match: Match): boolean {
+  return condition.some((and) => and.every((comparison) => evalComparison(comparison, match)))
+}
+
+// The pick the rules make for one match: the first rule whose condition matches (a
+// default rule always does), or null when none match — scored as no bet.
+export function rulePick(rules: Rule[], match: Match): BetType | null {
+  for (const rule of rules) {
+    if (rule.condition == null || conditionMatches(rule.condition, match)) return rule.pick
+  }
+  return null
+}
+
+// Score the rules over the finished matches with the same rule as a real bet: the
+// pick earns the match's odds for it when that outcome won, otherwise nothing.
+// Mirrors scoreSeed / Typerek::Ranking::VirtualPlayers#score (odds rounded to 2dp).
+export function scoreRules(rules: Rule[], finished: Match[]): RuleScore {
+  let points = 0
+  let accuracy = 0
+  for (const match of finished) {
+    const pick = rulePick(rules, match)
+    if (pick == null) continue
+    if (!winningBets(match.result_a, match.result_b).includes(pick)) continue
+    const odds = match.odds[pick]
+    if (odds == null) continue
+    points += Math.round(odds * 100) / 100
+    accuracy += 1
+  }
+  return { points: Math.round(points * 100) / 100, accuracy }
+}

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -41,6 +41,9 @@ interface Settings {
   // Show the experimental seed-driven strategy in the ranking (within the virtual
   // players overlay). Opt-in, off by default.
   seedStrategy: boolean
+  // Show the experimental rule-driven strategy in the ranking (within the virtual
+  // players overlay). Opt-in, off by default.
+  ruleStrategy: boolean
 }
 
 const DEFAULTS: Settings = {
@@ -54,6 +57,7 @@ const DEFAULTS: Settings = {
   matchOrderByRanking: false,
   virtualPlayers: false,
   seedStrategy: false,
+  ruleStrategy: false,
 }
 
 // Map between the server shape (snake_case, the API contract) and ours (camelCase).
@@ -73,6 +77,7 @@ function fromServer(settings: UserSettings | undefined): Settings {
     matchOrderByRanking: settings?.match_order_by_ranking ?? DEFAULTS.matchOrderByRanking,
     virtualPlayers: settings?.virtual_players ?? DEFAULTS.virtualPlayers,
     seedStrategy: settings?.seed_strategy ?? DEFAULTS.seedStrategy,
+    ruleStrategy: settings?.rule_strategy ?? DEFAULTS.ruleStrategy,
   }
 }
 
@@ -90,6 +95,7 @@ interface SettingsState extends Settings {
   setMatchOrderByRanking: (value: boolean) => Promise<void>
   setVirtualPlayers: (value: boolean) => Promise<void>
   setSeedStrategy: (value: boolean) => Promise<void>
+  setRuleStrategy: (value: boolean) => Promise<void>
 }
 
 const SettingsContext = createContext<SettingsState | undefined>(undefined)
@@ -152,6 +158,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     setVirtualPlayers: (virtualPlayers) =>
       persist({ virtualPlayers }, { virtual_players: virtualPlayers }),
     setSeedStrategy: (seedStrategy) => persist({ seedStrategy }, { seed_strategy: seedStrategy }),
+    setRuleStrategy: (ruleStrategy) => persist({ ruleStrategy }, { rule_strategy: ruleStrategy }),
   }
 
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -6,11 +6,13 @@ import { ErrorBox, Loading } from '@/components/Status'
 import RankingBumpChart from '@/components/RankingBumpChart'
 import RankingPointsChart from '@/components/RankingPointsChart'
 import SeedStrategyCard from '@/components/SeedStrategyCard'
+import RuleStrategyCard from '@/components/RuleStrategyCard'
 import { pointsDisplay } from '@/lib/format'
 import { useSettings } from '@/lib/settings'
 import { useDocumentTitle } from '@/lib/useDocumentTitle'
 import { rankEntries, parseRankSort, type RankSort } from '@/lib/ranking'
 import { scoreSeed } from '@/lib/seedStrategy'
+import { parseRules, scoreRules } from '@/lib/ruleStrategy'
 import type { RankingEntry } from '@/api/types'
 
 // Colour of the round position badge. Gold / silver / bronze for the podium, a
@@ -75,13 +77,15 @@ function fold(value: string): string {
 }
 
 // A ranking table row: a real entry, a virtual benchmark player (virtualKey set,
-// with a negative sentinel user id and no account to link to), or the seed
-// strategy (seed flag, rendered with the seed word instead of a profile link).
-type RankRow = RankingEntry & { virtualKey?: string; seed?: boolean }
+// with a negative sentinel user id and no account to link to), or one of the
+// experimental strategies — the seed (seed flag) or the rules (rule flag), both
+// rendered with a label and badge instead of a profile link.
+type RankRow = RankingEntry & { virtualKey?: string; seed?: boolean; rule?: boolean }
 
-// Sentinel user id for the seed strategy's row, distinct from the benchmark
-// players' -(index + 1) ids so React keys never collide.
+// Sentinel user ids for the strategy rows, distinct from the benchmark players'
+// -(index + 1) ids (and from each other) so React keys never collide.
 const SEED_ROW_ID = -1000
+const RULE_ROW_ID = -1001
 
 type View = 'table' | 'chart' | 'points'
 
@@ -95,7 +99,7 @@ function parseView(param: string | null): View {
 export default function RankingPage() {
   const { data, isLoading, isError } = useRanking()
   const { user } = useAuth()
-  const { drzewkoMode, favoriteUserIds, toggleFavorite, virtualPlayers, setVirtualPlayers, seedStrategy } =
+  const { drzewkoMode, favoriteUserIds, toggleFavorite, virtualPlayers, setVirtualPlayers, seedStrategy, ruleStrategy } =
     useSettings()
   const meRowRef = useRef<HTMLLIElement>(null)
   const [query, setQuery] = useState('')
@@ -110,6 +114,14 @@ export default function RankingPage() {
     const finishedMatches = matchData?.finished ?? []
     return trimmedSeed === '' || finishedMatches.length === 0 ? null : scoreSeed(trimmedSeed, finishedMatches)
   }, [trimmedSeed, matchData])
+  // The rule strategy rides the same overlay as the seed; its program lives here so
+  // it can also be scored into a ranking row. Only a parseable program scores.
+  const [rules, setRules] = useState('')
+  const ruleScore = useMemo(() => {
+    const finishedMatches = matchData?.finished ?? []
+    const parsed = parseRules(rules)
+    return !parsed.ok || finishedMatches.length === 0 ? null : scoreRules(parsed.rules, finishedMatches)
+  }, [rules, matchData])
 
   // The active subpage and the table sort both live in the URL (?view=chart&sort=hits)
   // so a refresh or shared link keeps the same tab and ordering — same pattern as
@@ -185,7 +197,23 @@ export default function RankingPage() {
         seed: true,
       }
     : null
-  const overlayRows = seedRow ? [...virtualRows, seedRow] : virtualRows
+
+  // The rule strategy joins the same overlay when its program parses and scores, but
+  // only when the (opt-in) rule_strategy setting is on. Like the seed row, an
+  // account-less row flagged `rule` so it renders with a label, not a profile link.
+  const ruleRow: RankRow | null =
+    ruleStrategy && ruleScore
+      ? {
+        position: 0,
+        previous_position: null,
+        user: { id: RULE_ROW_ID, username: 'Reguły' },
+        points: ruleScore.points,
+        accuracy: ruleScore.accuracy,
+        virtualKey: 'rule',
+        rule: true,
+      }
+    : null
+  const overlayRows = [...virtualRows, ...(seedRow ? [seedRow] : []), ...(ruleRow ? [ruleRow] : [])]
 
   // Merge by score; a stable sort keeps a real player ahead of a virtual one they
   // tie with and preserves the real field's own order.
@@ -411,6 +439,7 @@ export default function RankingPage() {
             </div>
           </div>
           {virtualPlayers && seedStrategy && <SeedStrategyCard seed={seed} onSeedChange={setSeed} />}
+          {virtualPlayers && ruleStrategy && <RuleStrategyCard rules={rules} onRulesChange={setRules} />}
           {visible.length === 0 ? (
             <div className="card card-body text-center text-muted">
               {query.trim()
@@ -455,18 +484,21 @@ export default function RankingPage() {
                       }`}
                     >
                       {virtual ? (
-                        <i className={`fas ${entry.seed ? 'fa-dice' : 'fa-robot'} text-xs`} aria-hidden="true" />
+                        <i
+                          className={`fas ${entry.seed ? 'fa-dice' : entry.rule ? 'fa-code' : 'fa-robot'} text-xs`}
+                          aria-hidden="true"
+                        />
                       ) : (
                         entry.position
                       )}
                     </span>
                     {augmented ? null : <Movement entry={entry} />}
                     <span className={`flex-1 truncate ${fav ? 'font-semibold' : 'font-medium'}`}>
-                      {entry.seed ? (
+                      {entry.seed || entry.rule ? (
                         <span className="inline-flex items-center gap-1.5 text-muted">
                           <span className="italic">{entry.user.username}</span>
                           <span className="rounded bg-surface px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted">
-                            seed
+                            {entry.seed ? 'seed' : 'reguły'}
                           </span>
                         </span>
                       ) : virtual ? (

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -26,6 +26,7 @@ type SettingsStats = {
   match_order_by_ranking: number
   virtual_players: number
   seed_strategy: number
+  rule_strategy: number
   // How many users have dark mode on (theme 'dark' or 'auto').
   theme: number
 }
@@ -89,6 +90,8 @@ export default function SettingsPage() {
     setVirtualPlayers,
     seedStrategy,
     setSeedStrategy,
+    ruleStrategy,
+    setRuleStrategy,
     pushResults,
     setPushResults,
     pushReminders,
@@ -393,24 +396,45 @@ export default function SettingsPage() {
           </label>
 
           {virtualPlayers && (
-            <div className="border-t border-line/40 bg-surface/40 px-4 py-3 pl-12 sm:px-5 sm:pl-14">
-              <label className="flex cursor-pointer items-start gap-3">
-                <input
-                  type="checkbox"
-                  className="mt-0.5 h-4 w-4 shrink-0 accent-brand"
-                  checked={seedStrategy}
-                  onChange={(event) => toggle('seed_strategy', setSeedStrategy, event.target.checked)}
-                />
-                <span className="leading-snug">
-                  <span className="block text-sm font-medium text-ink">Strategia z seeda</span>
-                  <span className="block text-xs text-muted">
-                    Eksperymentalna strategia sterowana słowem — z jego seeda losowane są typy 1/X/2.
-                    Pojawia się w rankingu jako dodatkowy gracz. Domyślnie ukryta.
+            <>
+              <div className="border-t border-line/40 bg-surface/40 px-4 py-3 pl-12 sm:px-5 sm:pl-14">
+                <label className="flex cursor-pointer items-start gap-3">
+                  <input
+                    type="checkbox"
+                    className="mt-0.5 h-4 w-4 shrink-0 accent-brand"
+                    checked={seedStrategy}
+                    onChange={(event) => toggle('seed_strategy', setSeedStrategy, event.target.checked)}
+                  />
+                  <span className="leading-snug">
+                    <span className="block text-sm font-medium text-ink">Strategia z seeda</span>
+                    <span className="block text-xs text-muted">
+                      Eksperymentalna strategia sterowana słowem — z jego seeda losowane są typy 1/X/2.
+                      Pojawia się w rankingu jako dodatkowy gracz. Domyślnie ukryta.
+                    </span>
+                    <UsageHint count={stats?.seed_strategy} />
                   </span>
-                  <UsageHint count={stats?.seed_strategy} />
-                </span>
-              </label>
-            </div>
+                </label>
+              </div>
+
+              <div className="border-t border-line/40 bg-surface/40 px-4 py-3 pl-12 sm:px-5 sm:pl-14">
+                <label className="flex cursor-pointer items-start gap-3">
+                  <input
+                    type="checkbox"
+                    className="mt-0.5 h-4 w-4 shrink-0 accent-brand"
+                    checked={ruleStrategy}
+                    onChange={(event) => toggle('rule_strategy', setRuleStrategy, event.target.checked)}
+                  />
+                  <span className="leading-snug">
+                    <span className="block text-sm font-medium text-ink">Strategia regułowa</span>
+                    <span className="block text-xs text-muted">
+                      Eksperymentalna strategia sterowana regułami „warunek =&gt; typ” (np. w1 &lt; 1.3 &amp; r &gt; 5
+                      =&gt; r). Pojawia się w rankingu jako dodatkowy gracz. Domyślnie ukryta.
+                    </span>
+                    <UsageHint count={stats?.rule_strategy} />
+                  </span>
+                </label>
+              </div>
+            </>
           )}
         </div>
       </section>

--- a/spec/requests/api/v1/profile_spec.rb
+++ b/spec/requests/api/v1/profile_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'API V1 Profile', type: :request do
         'drzewko_mode' => false, 'bet_lock' => false, 'push_enabled' => false,
         'push_results' => true, 'push_reminders' => true, 'theme' => 'light',
         'favorite_user_ids' => [], 'match_order_by_ranking' => false,
-        'virtual_players' => false, 'seed_strategy' => false
+        'virtual_players' => false, 'seed_strategy' => false, 'rule_strategy' => false
       )
     end
 
@@ -48,7 +48,8 @@ RSpec.describe 'API V1 Profile', type: :request do
       expect(response).to have_http_status(:ok)
       expect(json).to eq(
         'drzewko_mode' => 2, 'bet_lock' => 1, 'push_enabled' => 0,
-        'match_order_by_ranking' => 1, 'virtual_players' => 1, 'seed_strategy' => 0, 'theme' => 2
+        'match_order_by_ranking' => 1, 'virtual_players' => 1, 'seed_strategy' => 0, 'rule_strategy' => 0,
+        'theme' => 2
       )
     end
 
@@ -70,7 +71,7 @@ RSpec.describe 'API V1 Profile', type: :request do
         'drzewko_mode' => false, 'bet_lock' => true, 'push_enabled' => false,
         'push_results' => true, 'push_reminders' => true, 'theme' => 'light',
         'favorite_user_ids' => [], 'match_order_by_ranking' => false,
-        'virtual_players' => false, 'seed_strategy' => false
+        'virtual_players' => false, 'seed_strategy' => false, 'rule_strategy' => false
       )
       expect(user.reload.bet_lock?).to be(true)
     end
@@ -100,6 +101,15 @@ RSpec.describe 'API V1 Profile', type: :request do
       expect(response).to have_http_status(:ok)
       expect(json['settings']).to include('seed_strategy' => true)
       expect(user.reload.seed_strategy?).to be(true)
+    end
+
+    it 'updates the rule-strategy preference' do
+      patch '/api/v1/me/settings', params: { settings: { rule_strategy: true } },
+            headers: auth_headers(user), as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json['settings']).to include('rule_strategy' => true)
+      expect(user.reload.rule_strategy?).to be(true)
     end
 
     it 'accepts a valid theme preference' do


### PR DESCRIPTION
A new experimental "virtual player" you parameterize with a little `condition => pick` program, scored live over the finished matches like the seed strategy. Rules are read top-down (first match wins; a condition-less line is the default); a missing odd makes a comparison false so the rule falls through. The card carries a collapsible syntax cheat-sheet and a "Podejrzyj typy" preview, and the program appears as its own ranking row under the virtual-players overlay.

Gated behind a new opt-in `rule_strategy` setting, mirrored across the stack alongside `seed_strategy`.