### PR TITLE
Add mobile swipe navigation between Mecze and Ranking

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from 'react'
 import { Link, NavLink, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/auth/AuthContext'
 import { pointsDisplay } from '@/lib/format'
+import { useSwipeNav } from '@/lib/useSwipeNav'
 
 // Header + top navigation + footer, ported from the Rails application layout and
 // shared/_menu.html.erb.
@@ -10,6 +11,9 @@ export default function Layout({ children }: { children: ReactNode }) {
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
   const standing = user?.standing
+  // Mobile: swipe left/right to move between Mecze and Ranking. navKey changes only
+  // on a swipe, so the slide-in animation replays for swipes but not click nav.
+  const { dir, navKey } = useSwipeNav()
 
   const handleSignOut = () => {
     signOut()
@@ -98,7 +102,11 @@ export default function Layout({ children }: { children: ReactNode }) {
         </nav>
       </header>
 
-      <main className="container-app flex-1 py-6">{children}</main>
+      <main className="container-app flex-1 py-6">
+        <div key={navKey} className={dir === 'right' ? 'swipe-from-right' : dir === 'left' ? 'swipe-from-left' : ''}>
+          {children}
+        </div>
+      </main>
 
       <footer className="border-t border-line/70 py-4 text-center text-xs text-muted">
         Typerek &middot; Mistrzostwa Świata 2026

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -140,6 +140,24 @@
   .bet-lock-on { @apply text-brand hover:text-brand; }
 }
 
+/* Page enter animation for the mobile swipe between Mecze and Ranking: the incoming
+   page slides in from the side the swipe carried it from (see useSwipeNav). */
+@keyframes swipe-in-right {
+  from { transform: translateX(28px); opacity: 0; }
+  to   { transform: translateX(0);    opacity: 1; }
+}
+@keyframes swipe-in-left {
+  from { transform: translateX(-28px); opacity: 0; }
+  to   { transform: translateX(0);     opacity: 1; }
+}
+.swipe-from-right { animation: swipe-in-right 0.22s ease-out; }
+.swipe-from-left  { animation: swipe-in-left 0.22s ease-out; }
+
+@media (prefers-reduced-motion: reduce) {
+  .swipe-from-right,
+  .swipe-from-left { animation: none; }
+}
+
 /* "Drzewko mode" (opt-in via Ustawienia → Dostępność): the current user's row in
    the ranking flashes through vivid colors so it's impossible to miss. Every
    keyframe background is bright, so the dark ink text stays readable throughout. */

--- a/frontend/src/lib/useSwipeNav.ts
+++ b/frontend/src/lib/useSwipeNav.ts
@@ -1,0 +1,97 @@
+import { useEffect, useRef, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+// The swipeable top-level pages, in left-to-right order. A horizontal swipe moves
+// to the neighbouring page: swipe left → next (Ranking), swipe right → previous
+// (Mecze). Keep this in sync with the nav order in Layout.
+const PAGES = ['/matches', '/ranking'] as const
+type Page = (typeof PAGES)[number]
+
+// A swipe must travel at least this far horizontally, beat the vertical travel by
+// this ratio (so a mostly-vertical scroll never navigates), and finish within this
+// time — a quick flick, not a slow drag or a text selection.
+const MIN_DISTANCE = 60
+const HORIZONTAL_RATIO = 1.4
+const MAX_DURATION = 700
+
+// The direction the incoming page slides in from, used to pick the enter
+// animation. 'right' when we moved forward (swipe left), 'left' when back.
+export type SwipeDir = 'left' | 'right'
+
+// Should this gesture be left alone? True when it starts on a form control (taps /
+// text selection) or inside something that can itself scroll horizontally (the
+// ranking charts) — that content owns the gesture, not the page switcher.
+function shouldIgnore(target: EventTarget | null): boolean {
+  let el = target instanceof Element ? target : null
+  while (el && el !== document.body) {
+    const tag = el.tagName
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (el as HTMLElement).isContentEditable) {
+      return true
+    }
+    if (el.scrollWidth > el.clientWidth + 1) {
+      const overflowX = getComputedStyle(el).overflowX
+      if (overflowX === 'auto' || overflowX === 'scroll') return true
+    }
+    el = el.parentElement
+  }
+  return false
+}
+
+// Touch-driven navigation between the matches and ranking pages. Returns the slide
+// direction and a key that changes on each swipe; Layout uses the key to replay the
+// enter animation only on swipes (a normal click navigation leaves the key alone).
+export function useSwipeNav(): { dir: SwipeDir | null; navKey: number } {
+  const navigate = useNavigate()
+  const location = useLocation()
+  // Read the live path inside the once-attached listeners without re-subscribing on
+  // every navigation.
+  const pathRef = useRef(location.pathname)
+  pathRef.current = location.pathname
+
+  const [state, setState] = useState<{ dir: SwipeDir | null; navKey: number }>({ dir: null, navKey: 0 })
+
+  useEffect(() => {
+    let startX = 0
+    let startY = 0
+    let startT = 0
+    let active = false
+
+    const onStart = (event: TouchEvent) => {
+      const index = PAGES.indexOf(pathRef.current as Page)
+      if (index === -1 || event.touches.length !== 1 || shouldIgnore(event.target)) {
+        active = false
+        return
+      }
+      const touch = event.touches[0]
+      startX = touch.clientX
+      startY = touch.clientY
+      startT = Date.now()
+      active = true
+    }
+
+    const onEnd = (event: TouchEvent) => {
+      if (!active) return
+      active = false
+      const index = PAGES.indexOf(pathRef.current as Page)
+      if (index === -1) return
+      const touch = event.changedTouches[0]
+      const dx = touch.clientX - startX
+      const dy = touch.clientY - startY
+      if (Date.now() - startT > MAX_DURATION) return
+      if (Math.abs(dx) < MIN_DISTANCE || Math.abs(dx) < Math.abs(dy) * HORIZONTAL_RATIO) return
+      const next = index + (dx < 0 ? 1 : -1)
+      if (next < 0 || next >= PAGES.length) return
+      setState((prev) => ({ dir: dx < 0 ? 'right' : 'left', navKey: prev.navKey + 1 }))
+      navigate(PAGES[next])
+    }
+
+    document.addEventListener('touchstart', onStart, { passive: true })
+    document.addEventListener('touchend', onEnd, { passive: true })
+    return () => {
+      document.removeEventListener('touchstart', onStart)
+      document.removeEventListener('touchend', onEnd)
+    }
+  }, [navigate])
+
+  return state
+}


### PR DESCRIPTION
A horizontal touch swipe moves between the matches and ranking pages. The gesture only fires when it is clearly horizontal, fast and far enough, and it leaves form fields and horizontally scrollable charts to own their own gestures. The incoming page slides in from the swipe's direction (disabled under prefers-reduced-motion).