### PR TITLE
Swap cross-page swipe for in-tab swipe + a mobile bottom nav

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,7 +2,6 @@ import { useState, type ReactNode } from 'react'
 import { Link, NavLink, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/auth/AuthContext'
 import { pointsDisplay } from '@/lib/format'
-import { useSwipeNav } from '@/lib/useSwipeNav'
 
 // Header + top navigation + footer, ported from the Rails application layout and
 // shared/_menu.html.erb.
@@ -11,9 +10,6 @@ export default function Layout({ children }: { children: ReactNode }) {
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
   const standing = user?.standing
-  // Mobile: swipe left/right to move between Mecze and Ranking. navKey changes only
-  // on a swipe, so the slide-in animation replays for swipes but not click nav.
-  const { dir, navKey } = useSwipeNav()
 
   const handleSignOut = () => {
     signOut()
@@ -22,8 +18,17 @@ export default function Layout({ children }: { children: ReactNode }) {
 
   const linkClass = ({ isActive }: { isActive: boolean }) => `nav-link${isActive ? ' nav-link-active' : ''}`
 
+  // Mobile bottom tab bar links: a column-stacked icon + label, brand-tinted when
+  // active.
+  const bottomLinkClass = ({ isActive }: { isActive: boolean }) =>
+    `flex flex-1 flex-col items-center justify-center gap-0.5 py-2 text-xs font-medium transition-colors ${
+      isActive ? 'text-brand' : 'text-muted hover:text-ink'
+    }`
+
   return (
-    <div className="flex min-h-screen flex-col">
+    // Reserve space at the bottom on mobile so the fixed tab bar never covers the
+    // footer or the last content row (plus the iOS home-indicator safe area).
+    <div className="flex min-h-screen flex-col pb-[calc(4rem+env(safe-area-inset-bottom))] lg:pb-0">
       <header className="bg-header text-white shadow-sm">
         <nav className="container-app flex flex-wrap items-center justify-between gap-x-8 gap-y-2 py-3">
           <div className="flex w-full items-center justify-between lg:w-auto">
@@ -102,15 +107,22 @@ export default function Layout({ children }: { children: ReactNode }) {
         </nav>
       </header>
 
-      <main className="container-app flex-1 py-6">
-        <div key={navKey} className={dir === 'right' ? 'swipe-from-right' : dir === 'left' ? 'swipe-from-left' : ''}>
-          {children}
-        </div>
-      </main>
+      <main className="container-app flex-1 py-6">{children}</main>
 
       <footer className="border-t border-line/70 py-4 text-center text-xs text-muted">
         Typerek &middot; Mistrzostwa Świata 2026
       </footer>
+
+      {/* Mobile bottom tab bar: the two most-used views (Mecze, Ranking) under the
+          thumb. Hidden on desktop (≥lg), where the top nav already carries them. */}
+      <nav className="fixed inset-x-0 bottom-0 z-40 flex border-t border-line bg-raised pb-[env(safe-area-inset-bottom)] shadow-[0_-1px_3px_rgba(0,0,0,0.06)] lg:hidden">
+        <NavLink to="/matches" className={bottomLinkClass}>
+          <i className="fas fa-futbol text-lg" aria-hidden="true" /> Mecze
+        </NavLink>
+        <NavLink to="/ranking" className={bottomLinkClass}>
+          <i className="fas fa-trophy text-lg" aria-hidden="true" /> Ranking
+        </NavLink>
+      </nav>
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -140,8 +140,8 @@
   .bet-lock-on { @apply text-brand hover:text-brand; }
 }
 
-/* Page enter animation for the mobile swipe between Mecze and Ranking: the incoming
-   page slides in from the side the swipe carried it from (see useSwipeNav). */
+/* Enter animation for the mobile tab swipe (see useSwipeTabs): the incoming tab
+   slides in from the side the swipe carried it from. */
 @keyframes swipe-in-right {
   from { transform: translateX(28px); opacity: 0; }
   to   { transform: translateX(0);    opacity: 1; }

--- a/frontend/src/lib/useSwipeTabs.ts
+++ b/frontend/src/lib/useSwipeTabs.ts
@@ -1,26 +1,24 @@
 import { useEffect, useRef, useState } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
 
-// The swipeable top-level pages, in left-to-right order. A horizontal swipe moves
-// to the neighbouring page: swipe left → next (Ranking), swipe right → previous
-// (Mecze). Keep this in sync with the nav order in Layout.
-const PAGES = ['/matches', '/ranking'] as const
-type Page = (typeof PAGES)[number]
+// A horizontal touch swipe between an ordered list of in-page tabs: swipe left →
+// next tab, swipe right → previous, clamped at both ends (no wrap). The visible
+// tab buttons stay the primary control; this gesture is purely additive. Used on
+// the Matches page (Aktualne / Zakończone).
 
 // A swipe must travel at least this far horizontally, beat the vertical travel by
-// this ratio (so a mostly-vertical scroll never navigates), and finish within this
-// time — a quick flick, not a slow drag or a text selection.
+// this ratio (so a mostly-vertical scroll never switches tabs), and finish within
+// this time — a quick flick, not a slow drag or a text selection.
 const MIN_DISTANCE = 60
 const HORIZONTAL_RATIO = 1.4
 const MAX_DURATION = 700
 
-// The direction the incoming page slides in from, used to pick the enter
-// animation. 'right' when we moved forward (swipe left), 'left' when back.
+// The direction the incoming tab slides in from, used to pick the enter animation.
+// 'right' when we moved forward (swipe left), 'left' when back.
 export type SwipeDir = 'left' | 'right'
 
 // Should this gesture be left alone? True when it starts on a form control (taps /
-// text selection) or inside something that can itself scroll horizontally (the
-// ranking charts) — that content owns the gesture, not the page switcher.
+// text selection) or inside something that can itself scroll horizontally — that
+// content owns the gesture, not the tab switcher.
 function shouldIgnore(target: EventTarget | null): boolean {
   let el = target instanceof Element ? target : null
   while (el && el !== document.body) {
@@ -37,16 +35,19 @@ function shouldIgnore(target: EventTarget | null): boolean {
   return false
 }
 
-// Touch-driven navigation between the matches and ranking pages. Returns the slide
-// direction and a key that changes on each swipe; Layout uses the key to replay the
-// enter animation only on swipes (a normal click navigation leaves the key alone).
-export function useSwipeNav(): { dir: SwipeDir | null; navKey: number } {
-  const navigate = useNavigate()
-  const location = useLocation()
-  // Read the live path inside the once-attached listeners without re-subscribing on
-  // every navigation.
-  const pathRef = useRef(location.pathname)
-  pathRef.current = location.pathname
+// Touch-driven switching between a page's tabs. Pass the ordered tab values, the
+// current value and a setter; returns the slide direction and a key that changes on
+// each swipe, so the consumer can replay the enter animation only on swipes (a tab
+// click leaves the key alone).
+export function useSwipeTabs<T extends string>(
+  values: readonly T[],
+  current: T,
+  onChange: (next: T) => void,
+): { dir: SwipeDir | null; navKey: number } {
+  // Keep the latest props reachable from the once-attached listeners without
+  // re-subscribing on every tab change.
+  const ref = useRef({ values, current, onChange })
+  ref.current = { values, current, onChange }
 
   const [state, setState] = useState<{ dir: SwipeDir | null; navKey: number }>({ dir: null, navKey: 0 })
 
@@ -57,8 +58,7 @@ export function useSwipeNav(): { dir: SwipeDir | null; navKey: number } {
     let active = false
 
     const onStart = (event: TouchEvent) => {
-      const index = PAGES.indexOf(pathRef.current as Page)
-      if (index === -1 || event.touches.length !== 1 || shouldIgnore(event.target)) {
+      if (event.touches.length !== 1 || shouldIgnore(event.target)) {
         active = false
         return
       }
@@ -72,7 +72,8 @@ export function useSwipeNav(): { dir: SwipeDir | null; navKey: number } {
     const onEnd = (event: TouchEvent) => {
       if (!active) return
       active = false
-      const index = PAGES.indexOf(pathRef.current as Page)
+      const { values, current, onChange } = ref.current
+      const index = values.indexOf(current)
       if (index === -1) return
       const touch = event.changedTouches[0]
       const dx = touch.clientX - startX
@@ -80,9 +81,9 @@ export function useSwipeNav(): { dir: SwipeDir | null; navKey: number } {
       if (Date.now() - startT > MAX_DURATION) return
       if (Math.abs(dx) < MIN_DISTANCE || Math.abs(dx) < Math.abs(dy) * HORIZONTAL_RATIO) return
       const next = index + (dx < 0 ? 1 : -1)
-      if (next < 0 || next >= PAGES.length) return
+      if (next < 0 || next >= values.length) return
       setState((prev) => ({ dir: dx < 0 ? 'right' : 'left', navKey: prev.navKey + 1 }))
-      navigate(PAGES[next])
+      onChange(values[next])
     }
 
     document.addEventListener('touchstart', onStart, { passive: true })
@@ -91,7 +92,7 @@ export function useSwipeNav(): { dir: SwipeDir | null; navKey: number } {
       document.removeEventListener('touchstart', onStart)
       document.removeEventListener('touchend', onEnd)
     }
-  }, [navigate])
+  }, [])
 
   return state
 }

--- a/frontend/src/pages/MatchesPage.tsx
+++ b/frontend/src/pages/MatchesPage.tsx
@@ -10,6 +10,7 @@ import { ErrorBox, Loading } from '@/components/Status'
 import type { BetType, Match } from '@/api/types'
 import { useSettings } from '@/lib/settings'
 import { useDocumentTitle } from '@/lib/useDocumentTitle'
+import { useSwipeTabs } from '@/lib/useSwipeTabs'
 
 function DayBadge({ iso }: { iso: string }) {
   const label = relativeDay(iso)
@@ -101,6 +102,10 @@ export default function MatchesPage() {
   const tab: 'future' | 'finished' = searchParams.get('status') === 'finished' ? 'finished' : 'future'
   const selectTab = (next: 'future' | 'finished') =>
     setSearchParams(next === 'finished' ? { status: 'finished' } : {}, { replace: true })
+  // Mobile: swipe left/right to move between the Aktualne / Zakończone tabs. navKey
+  // changes only on a swipe, so the slide-in animation replays for swipes but not
+  // for a tab click.
+  const { dir, navKey } = useSwipeTabs(['future', 'finished'] as const, tab, selectTab)
 
   useDocumentTitle('Mecze')
 
@@ -126,11 +131,13 @@ export default function MatchesPage() {
         </button>
       </div>
 
-      {tab === 'future' ? (
-        <MatchSection matches={data.not_finished} />
-      ) : (
-        <MatchSection matches={data.finished} />
-      )}
+      <div key={navKey} className={dir === 'right' ? 'swipe-from-right' : dir === 'left' ? 'swipe-from-left' : ''}>
+        {tab === 'future' ? (
+          <MatchSection matches={data.not_finished} />
+        ) : (
+          <MatchSection matches={data.finished} />
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
UX feedback: swiping between whole pages (Mecze <-> Ranking) was disorienting. Instead, a horizontal swipe now switches tabs *within* a page, and the two most-used views get a fixed bottom tab bar on mobile.

- useSwipeNav -> useSwipeTabs: a generic hook that swipes between an ordered list of in-page tabs (clamped, no wrap), reusing the same gesture thresholds and shouldIgnore guard.
- MatchesPage: swipe toggles the Aktualne / Zakończone tabs, with the slide-in animation replaying only on swipes (not tab clicks). Ranking keeps tap-only tabs (its charts own the horizontal gesture).
- Layout: add a mobile-only bottom tab bar (Mecze, Ranking) honouring the iOS safe area, and reserve space so it never covers the footer or last row. The burger menu is unchanged.