### PR TITLE
Add a one-time dismissible "bez dogrywki" note to the matches page

### DIFF
--- a/frontend/src/components/InfoNote.tsx
+++ b/frontend/src/components/InfoNote.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react'
+import { usePersistentState } from '@/lib/usePersistentState'
+
+// A one-time informational banner the user can dismiss for good. The dismissal
+// is remembered in localStorage under `storageKey`, so the note shows once per
+// device and never comes back. If the message changes and you want it to
+// reappear, bump the key (e.g. add a version suffix). Uses the warm "highlight"
+// tone reserved for notice banners, so it reads well in light and dark mode.
+export default function InfoNote({
+  storageKey,
+  children,
+}: {
+  storageKey: string
+  children: ReactNode
+}) {
+  const [dismissed, setDismissed] = usePersistentState(storageKey, '')
+
+  if (dismissed === '1') return null
+
+  return (
+    <div role="note" className="mb-4 flex items-start gap-3 rounded-lg bg-highlight px-4 py-3 text-sm text-highlight-fg">
+      <i className="fas fa-info-circle mt-0.5 shrink-0" aria-hidden="true" />
+      <span className="flex-1">{children}</span>
+      <button
+        type="button"
+        onClick={() => setDismissed('1')}
+        className="shrink-0 opacity-70 transition-opacity hover:opacity-100"
+        aria-label="Zamknij"
+      >
+        <i className="fas fa-times" aria-hidden="true" />
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/MatchesPage.tsx
+++ b/frontend/src/pages/MatchesPage.tsx
@@ -5,6 +5,7 @@ import { BET_LEGEND, BET_TYPES } from '@/lib/bets'
 import MatchLine from '@/components/MatchLine'
 import { useLocalStarted } from '@/lib/useLocalStarted'
 import BetGrid from '@/components/BetGrid'
+import InfoNote from '@/components/InfoNote'
 import LockToggle from '@/components/LockToggle'
 import { ErrorBox, Loading } from '@/components/Status'
 import type { BetType, Match } from '@/api/types'
@@ -117,6 +118,11 @@ export default function MatchesPage() {
       <h1 className="mb-4 flex items-center gap-2">
         <i className="fas fa-futbol text-brand" aria-hidden="true" /> Mecze
       </h1>
+
+      <InfoNote storageKey="typerek.notice.noExtraTime">
+        Typujemy wynik <strong>bez dogrywki</strong> — liczy się rezultat po 90 minutach, wliczając doliczony czas gry
+        (jeśli jest).
+      </InfoNote>
 
       <div className="mb-5 flex border-b border-line">
         <button type="button" onClick={() => selectTab('future')} className={`tab${tab === 'future' ? ' tab-active' : ''}`}>


### PR DESCRIPTION
Show a closeable info banner at the top of Mecze explaining that bets are scored on the result after 90 minutes (including stoppage time, excluding extra time). The dismissal is persisted in localStorage, so it appears once per device and never returns.

InfoNote is a reusable component keyed by a localStorage slug; bump the key to re-show a changed message.